### PR TITLE
Prevent interactive input during pytest collection Verified local setup: pytest passes on Windows (Python 3.13)

### DIFF
--- a/bot/test_brain.py
+++ b/bot/test_brain.py
@@ -21,6 +21,9 @@ import aiml
 import os.path
 
 k = aiml.Kernel()
-k.loadBrain("alice.brn")
+BRAIN_PATH = os.path.join(os.path.dirname(__file__), "alice.brn")
+k.loadBrain(BRAIN_PATH)
 
-while True: print((k.respond(eval(input("Pregunta > "))))) 
+if __name__ == "__main__":
+    while True:
+        print(k.respond(eval(input("Pregunta > "))))


### PR DESCRIPTION
### What I did
- Forked and set up Speak-AI locally on Windows
- Installed all required dependencies
- Ran the full pytest test suite successfully

### Why this PR
This PR documents that the project can be set up and tested successfully
on a Windows environment with Python 3.13.
It also helps future contributors during onboarding.

### Environment
- OS: Windows 10
- Python: 3.13.9
- pytest: 9.0.2

### Test Results
All tests passed:
- 28 tests collected
- 28 tests passed

### Notes
This is my first contribution as I start exploring Speak-AI for GSoC 2026.
I’m currently going through the codebase to pick a task to work on next.
