### PR TITLE
refactor: migrate backend to Kokoro-ONNX and add multilingual mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 .0sugar
 *~
 *.pyc
+models/

--- a/README.md
+++ b/README.md
@@ -53,3 +53,16 @@ The `not-gstreamer1` branch is a backport of features and bug fixes
 from the `master` branch for ongoing maintenance of the activity on
 Fedora 18 systems which don't have well-functioning GStreamer 1
 packages.
+
+### Model Setup (Kokoro-ONNX)
+
+This activity uses the lightweight Kokoro-ONNX backend for high-quality, multilingual text-to-speech. Because the model weights are large binary files (~200MB combined), they are not bundled directly in this repository.
+
+**Automated Download:**
+You do not need to download the models manually. Upon launching the activity for the first time, the backend will automatically download the required ONNX model (`kokoro-v1.0.fp16.onnx`) and the voice definitions (`voices-v1.0.bin`) from the official release repositories. 
+
+**Storage Location:**
+To adhere to Sugar OS sandboxing guidelines, these files are saved directly to your local writable activity root directory rather than the source code folder. You can find them here:
+`~/.sugar/default/org.sugarlabs.SpeakActivity/data/models/`
+
+*(Note: The initial download may take a few minutes depending on your internet connection. Subsequent launches will detect the cached models and boot instantly.)*

--- a/activity.py
+++ b/activity.py
@@ -949,62 +949,24 @@ class SpeakActivity(activity.Activity):
         self._persona_box.show_all()
         
     def _kokoro_voice_changed_event_cb(self, widget, event, voice_name):
-        # Show info label(Indication of voice changing) upon click
-        info_label = Gtk.Label()
-        info_label.set_markup('<span foreground="blue" size="large">%s</span>' % _('Please wait...'))
-        self._kokoro_voice_box.pack_start(info_label, False, False, style.DEFAULT_PADDING)
-        info_label.show()
-        while Gtk.events_pending():
-            Gtk.main_iteration()
+        # Update UI (Visual Feedback)
+        current_voice = speech.get_speech().current_kokoro_voice
+        
+        # Deselect old voice
+        if current_voice in self._kokoro_voice_evboxes:
+            self._kokoro_voice_evboxes[current_voice].modify_bg(
+                0, style.COLOR_BLACK.get_gdk_color())
+        
+        # Select new voice
+        if voice_name in self._kokoro_voice_evboxes:
+            self._kokoro_voice_evboxes[voice_name].modify_bg(
+                0, style.COLOR_BUTTON_GREY.get_gdk_color())
 
-        def async_check_and_update():
-            kokoro_pipeline = speech.get_speech().kokoro_pipeline
-            is_local = False
-            if kokoro_pipeline:
-                if not is_local:
-                    try:
-                        import huggingface_hub
-                        repo_id = kokoro_pipeline.repo_id
-                        message = _('This voice is being downloaded, please wait')
-                        info_label.set_markup('<span foreground="blue" size="large">%s</span>' % message)
-                        voice_path = huggingface_hub.hf_hub_download(
-                            repo_id=repo_id,
-                            filename=f'voices/{voice_name}.pt',
-                            cache_dir=None,
-                            force_download=False,
-                            resume_download=False
-                        )
-                        is_local = os.path.exists(voice_path)
-                    except ImportError:
-                        message = _('Hugging Face Hub is not installed')
-                        info_label.set_markup('<span foreground="red" size="large">%s</span>' % message)
-                    except huggingface_hub.errors.LocalEntryNotFoundError:
-                        message = _("Can't download voice as there's no internet connection")
-                        info_label.set_markup('<span foreground="red" size="large">%s</span>' % message)
-            else:
-                is_local = True
-
-            if is_local:
-                message = _('Changing voice, please wait')
-                info_label.set_markup('<span foreground="green" size="large">%s</span>' % message)
-                # Now update UI for voice selection
-                for old_name, evbox in self._kokoro_voice_evboxes.items():
-                    if old_name == speech.get_speech().current_kokoro_voice:
-                        evbox.modify_bg(0, style.COLOR_BLACK.get_gdk_color())
-                self._kokoro_voice_evboxes[voice_name].modify_bg(0, style.COLOR_BUTTON_GREY.get_gdk_color())
-
-                # Actually set the voice (may trigger download from Hugging Face Hub)
-                speech.get_speech().set_kokoro_voice(voice_name)
-                self.face.say_notification(_('Kokoro voice changed'))
-
-            while Gtk.events_pending():
-                Gtk.main_iteration()
-
-            def _remove_info_label():
-                self._kokoro_voice_box.remove(info_label)
-            GLib.timeout_add(3000, _remove_info_label)
-
-        GLib.idle_add(async_check_and_update)
+        # Set the voice in the backend
+        speech.get_speech().set_kokoro_voice(voice_name)
+        
+        # Notify user
+        self.face.say_notification(_('Voice changed to %s') % voice_name)
 
     def _persona_changed_event_cb(self, widget, event, persona_name):
         """Handle persona selection change"""
@@ -1279,6 +1241,8 @@ class SpeakActivity(activity.Activity):
 
     def _try_llm_response(self, text):
         """Try to get response from LLM. Returns response string or None if failed."""
+        if not text or not isinstance(text, str):
+            return None
 
         if is_profane(text):
             return "Hmm, that word isn't very friendly. Talking with kind words makes chatting more fun! Can you try again with a friendly word?"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 llama-cpp-python
-huggingface_hub
-misaki
 spacy
 numpy
-torch
-transformers
 requests
+kokoro-onnx
+soundfile

--- a/speech.py
+++ b/speech.py
@@ -18,23 +18,73 @@
 
 import numpy
 import threading
-
-from gi.repository import Gst
-from gi.repository import GLib
-from gi.repository import GObject
-
+import os
+import sys
 import logging
+import urllib.request
+from sugar3.activity.activity import get_activity_root
+
+try:
+    import gi
+    gi.require_version('Gst', '1.0')
+    from gi.repository import Gst, GLib, GObject
+except ImportError:
+    print("WARNING: GStreamer not found. Audio will not play.")
+
+    class Gst:
+        class Pipeline:
+            pass
+
+        class State:
+            PLAYING = 1
+            NULL = 0
+
+        class Buffer:
+            @staticmethod
+            def new_wrapped(d):
+                return d
+
+        class Caps:
+            @staticmethod
+            def from_string(s):
+                return s
+
+        class FlowReturn:
+            OK = 0
+
+    class GObject:
+        TYPE_PYOBJECT = object
+        SIGNAL_RUN_FIRST = "run-first"
+
+
 logger = logging.getLogger('speak')
 
-from sugar3.speech import GstSpeechPlayer
+try:
+    from sugar3.speech import GstSpeechPlayer
+except ImportError:
+    logger.warning("sugar3 not found (running in venv?). Using MockSpeechPlayer.")
+
+    class GstSpeechPlayer(GObject.GObject if 'GObject' in sys.modules else object):
+        def __init__(self):
+            if 'GObject' in sys.modules:
+                GObject.GObject.__init__(self)
+            self.pipeline = None
+
+        def stop_sound_device(self):
+            pass
+
+        def restart_sound_device(self):
+            pass
+
 
 # Kokoro TTS imports
+# Check for Kokoro ONNX availability
 try:
-    from kokoro import KPipeline
+    from kokoro_onnx import Kokoro
     KOKORO_AVAILABLE = True
 except ImportError:
     KOKORO_AVAILABLE = False
-    logger.warning("Kokoro not available, falling back to espeak")
+    logger.warning("kokoro-onnx not available, falling back to espeak")
 
 PITCH_MIN = 0
 PITCH_MAX = 200
@@ -50,34 +100,131 @@ class Speech(GstSpeechPlayer):
     }
 
     def __init__(self):
-        GstSpeechPlayer.__init__(self)
+        try:
+            GstSpeechPlayer.__init__(self)
+        except Exception:
+            pass
+
         self.pipeline = None
-        
+
         # Initialize Kokoro pipeline if available
-        self.kokoro_pipeline = None
+        self.kokoro = None
         if KOKORO_AVAILABLE:
-            threading.Thread(target=self.setup_kokoro).start()
-        
+            threading.Thread(target=self.setup_kokoro, daemon=True).start()
+
         # Predefined Kokoro voices for future GUI selection - TODO
         self.kokoro_voices = [
-            'af_heart', 'af_alloy', 'af_aoede', 'af_bella', 'af_jessica', 'af_kore', 'af_nicole',
-            'af_nova', 'af_river', 'af_sarah', 'af_sky','am_adam', 'am_echo', 'am_eric', 'am_fenrir',
-            'am_adam', 'am_echo', 'am_eric', 'am_fenrir', 'am_liam', 'am_michael', 'am_onyx',
-            'am_puck', 'am_santa', 'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily', 'bm_daniel',
-            'bm_fable', 'bm_george', 'bm_lewis', 'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro',
-            'jm_kumo', 'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi', 'zm_yunjian',
-            'zm_yunxi', 'zm_yunxia', 'zm_yunyang', 'ef_dora', 'em_alex', 'em_santa',
-            'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
-            'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
+            'af_heart', 'af_alloy', 'af_aoede', 'af_bella', 'af_jessica',
+            'af_kore', 'af_nicole', 'af_nova', 'af_river', 'af_sarah',
+            'af_sky', 'am_adam', 'am_echo', 'am_eric', 'am_fenrir',
+            'am_liam', 'am_michael', 'am_onyx', 'am_puck', 'am_santa',
+            'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily', 'bm_daniel',
+            'bm_fable', 'bm_george', 'bm_lewis', 'jf_alpha', 'jf_gongitsune',
+            'jf_nezumi', 'jf_tebukuro', 'jm_kumo', 'zf_xiaobei', 'zf_xiaoni',
+            'zf_xiaoxiao', 'zf_xiaoyi', 'zm_yunjian', 'zm_yunxi', 'zm_yunxia',
+            'zm_yunyang', 'ef_dora', 'em_alex', 'em_santa', 'ff_siwis',
+            'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi', 'if_sara',
+            'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
         ]
         self.current_kokoro_voice = 'af_heart'
 
-        self._cb = {}
-        for cb in ['peak', 'wave', 'idle']:
-            self._cb[cb] = None
+        self._cb = {'peak': None, 'wave': None, 'idle': None}
+        self._current_pipeline_type = None  # Track pipeline type to avoid rebuilds
 
     def setup_kokoro(self):
-        self.kokoro_pipeline = KPipeline(lang_code='a')
+        activity_root = get_activity_root()
+        model_dir = os.path.join(activity_root, "models")
+        os.makedirs(model_dir, exist_ok=True)
+
+        model_path = os.path.join(model_dir, "kokoro-v1.0.fp16.onnx")
+        voices_path = os.path.join(model_dir, "voices-v1.0.bin")
+
+        # Expected file sizes for validation (prevents corrupted partial downloads)
+        EXPECTED_MODEL_SIZE = 177464787  # ~169MB
+        EXPECTED_VOICES_SIZE = 28214398  # ~27MB
+
+        def is_valid_download(filepath, expected_size):
+            """Check if file exists and has the expected size."""
+            if not os.path.exists(filepath):
+                return False
+            actual_size = os.path.getsize(filepath)
+            if actual_size != expected_size:
+                logger.warning(f"File {filepath} has invalid size: {actual_size} (expected {expected_size})")
+                return False
+            return True
+
+        # Created a progress bar function that bypasses Sugar's hidden logs
+        def download_progress(block_num, block_size, total_size):
+            if total_size > 0:
+                percent = min(100, int(block_num * block_size * 100 / total_size))
+                sys.stdout.write(f"\r Downloading models... {percent}% complete")
+                sys.stdout.flush()
+
+        # Check and download model file
+        if not is_valid_download(model_path, EXPECTED_MODEL_SIZE):
+            # Remove corrupted/incomplete file if it exists
+            if os.path.exists(model_path):
+                print("\n Removing incomplete/corrupted model file...")
+                os.remove(model_path)
+            print("\n Kokoro ONNX model not found. Starting 170MB download...")
+            try:
+                urllib.request.urlretrieve(
+                    "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.fp16.onnx",
+                    model_path,
+                    reporthook=download_progress
+                )
+                if is_valid_download(model_path, EXPECTED_MODEL_SIZE):
+                    print("\n Model downloaded successfully!")
+                else:
+                    print("\n Model download incomplete! Please check your connection and try again.")
+                    if os.path.exists(model_path):
+                        os.remove(model_path)
+            except Exception as e:
+                logger.error(f"Model download failed: {e}")
+                if os.path.exists(model_path):
+                    os.remove(model_path)
+
+        # Check and download voices file
+        if not is_valid_download(voices_path, EXPECTED_VOICES_SIZE):
+            # Remove corrupted/incomplete file if it exists
+            if os.path.exists(voices_path):
+                print("\n Removing incomplete/corrupted voices file...")
+                os.remove(voices_path)
+            print("\n Voices file not found. Starting 26MB download...")
+            try:
+                urllib.request.urlretrieve(
+                    "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin",
+                    voices_path,
+                    reporthook=download_progress
+                )
+                if is_valid_download(voices_path, EXPECTED_VOICES_SIZE):
+                    print("\n Voices downloaded successfully!")
+                else:
+                    print("\n Voices download incomplete! Please check your connection and try again.")
+                    if os.path.exists(voices_path):
+                        os.remove(voices_path)
+            except Exception as e:
+                logger.error(f"Voices download failed: {e}")
+                if os.path.exists(voices_path):
+                    os.remove(voices_path)
+
+        if os.path.exists(model_path) and os.path.exists(voices_path):
+            try:
+                self.kokoro = Kokoro(model_path, voices_path)
+                print("\n Kokoro ONNX Engine Loaded and Ready!")
+                # Warm-up inference to eliminate first-call latency
+                try:
+                    self.kokoro.create("Hi", voice=self.current_kokoro_voice,
+                                       speed=1.0, lang='en-us')
+                    print(" Kokoro warm-up complete.")
+                except Exception as e:
+                    logger.warning(f"Kokoro warm-up failed (non-fatal): {e}")
+            except Exception as e:
+                logger.error(f"Failed to load Kokoro ONNX: {e}")
+                self.kokoro = None
+        else:
+            logger.warning(f"Kokoro model files not found at {model_dir}")
+            self.kokoro = None
 
     def disconnect_all(self):
         for cb in ['peak', 'wave', 'idle']:
@@ -111,110 +258,142 @@ class Speech(GstSpeechPlayer):
 
     def get_addon_kokoro_voices(self):
         """Return the add-on Kokoro voices for UI display."""
-        return [v for v in self.kokoro_voices if v not in self.get_default_kokoro_voices()]
+        return [
+            v for v in self.kokoro_voices
+            if v not in self.get_default_kokoro_voices()
+        ]
 
-    def make_pipeline(self):
+    def make_pipeline(self, use_kokoro=False):
+        # Reuse existing pipeline if the type hasn't changed
+        if self.pipeline is not None and self._current_pipeline_type == use_kokoro:
+            try:
+                self.pipeline.set_state(Gst.State.NULL)
+                # For kokoro, need a fresh appsrc, so rebuild
+                if use_kokoro:
+                    pass  # fall through to rebuild
+                else:
+                    self.pipeline.set_state(Gst.State.PLAYING)
+                    return
+            except Exception:
+                pass
+
         if self.pipeline is not None:
-            self.stop_sound_device()
+            try:
+                self.pipeline.set_state(Gst.State.NULL)
+            except Exception:
+                pass
             del self.pipeline
+
+        self._current_pipeline_type = use_kokoro
 
         # If kokoro is available build pipeline using kokoro, else use espeak
         # The pipeline has two sinks : `ears` & `fakesink`
         # ears play to the audio device - we hear the sound output from Kokoro / espeak
         # fakesink is used to draw the mouth movements
 
-        if KOKORO_AVAILABLE and self.kokoro_pipeline:
+        if use_kokoro:
             # Build pipeline for Kokoro using appsrc
             # fakesink audio converted to S16LE 16KHz so it's backward compatable with the previous mouth drawing logic
-            cmd = 'appsrc name=kokoro_src' \
-                ' ! audioconvert' \
-                ' ! audio/x-raw,channels=(int)1,format=F32LE,rate=24000' \
-                ' ! tee name=me' \
-                ' me.! queue ! autoaudiosink name=ears' \
-                ' me.! queue ! audioconvert ! audioresample ! audio/x-raw,format=S16LE,channels=1,rate=16000 ! fakesink name=sink'
-            
+            cmd = (
+                'appsrc name=kokoro_src format=time is-live=true '
+                'do-timestamp=true ! audio/x-raw,format=F32LE,rate=24000,'
+                'channels=1,layout=interleaved ! audioconvert ! audioresample '
+                '! tee name=me me. ! queue ! autoaudiosink name=ears '
+                'me. ! queue ! audioconvert ! audioresample ! '
+                'audio/x-raw,format=S16LE,channels=1,rate=16000 ! '
+                'fakesink name=sink'
+            )
         else:
             # Fallback to espeak pipeline
-            cmd = 'espeak name=espeak' \
-                ' ! capsfilter name=caps' \
-                ' ! tee name=me' \
-                ' me.! queue ! autoaudiosink name=ears' \
-                ' me.! queue ! fakesink name=sink'
-            
-        self.pipeline = Gst.parse_launch(cmd)
-        
+            cmd = (
+                'espeak name=espeak ! capsfilter name=caps ! tee name=me '
+                'me. ! queue ! audioconvert ! audioresample ! autoaudiosink '
+                'name=ears me. ! queue ! audioconvert ! audioresample ! '
+                'audio/x-raw,format=S16LE,channels=1,rate=16000 ! '
+                'fakesink name=sink'
+            )
+
+        try:
+            self.pipeline = Gst.parse_launch(cmd)
+            self.pipeline.set_state(Gst.State.PLAYING)
+        except Exception as e:
+            logger.error(f"Failed to launch GStreamer pipeline: {e}")
+            return
+
         # Configure caps to ensure compatibility with numpy int16 processing
-        if not (KOKORO_AVAILABLE and self.kokoro_pipeline):
+        if not use_kokoro:
             # force a sample bit width to match our numpy code below
             caps = self.pipeline.get_by_name('caps')
-            want = 'audio/x-raw,channels=(int)1,depth=(int)16'
-            caps.set_property('caps', Gst.caps_from_string(want))
+            if caps:
+                want = 'audio/x-raw,format=S16LE,channels=1'
+                caps.set_property('caps', Gst.caps_from_string(want))
 
         # grab reference to the output element for scheduling mouth moves
         ears = self.pipeline.get_by_name('ears')
 
         def handoff(element, data, pad):
             size = data.get_size()
-
             if size == 0:
                 logger.debug("Size is equal to zero, skipping handoff")
                 return True
 
+            # Assume 16-bit, 1 channel, 16000 Hz for duration calculation
+            samples = size // 2  # 16-bit = 2 bytes per sample
+            fallback_duration = samples * Gst.SECOND // 16000
+            actual_duration = fallback_duration
+
             # Handle invalid duration
-            if ( data.duration == 0 
-                or data.duration == Gst.CLOCK_TIME_NONE 
-                or data.duration > Gst.SECOND * 10
-            ):
-                logger.debug("Invalid duration detected, using fallback duration calculation")
-                # Assume 16-bit, 1 channel, 16000 Hz for duration calculation
-                SAMPLE_RATE = 16000
-                samples = size // 2  # 16-bit = 2 bytes per sample
-                fallback_duration = samples * Gst.SECOND // SAMPLE_RATE
+            if (data.duration == 0 or data.duration == Gst.CLOCK_TIME_NONE or
+                    data.duration > Gst.SECOND * 10):
                 actual_duration = fallback_duration
             else:
                 actual_duration = data.duration
 
             npc = 50000000  # npc - nanoseconds per chunk; here 50ms audio = 1 chunks
-            bpc = size * npc // actual_duration  # bytes per chunk
+            bpc = size * npc // actual_duration if actual_duration > 0 else 0  # bytes per chunk
             bpc = bpc // 2 * 2  # force alignment for int16
 
             # Ensuring minimum chunk size
             if bpc == 0:
-                bpc = min(4096, size)  # I think 4096 is a reasonable chunk size, if not will change later.
-                bpc = bpc // 2 * 2  # force alignment for int16
+                # I think 4096 is a reasonable chunk size, if not will change later.
+                bpc = min(4096, size // 2 * 2)
 
-            a = [] # list of waveform data
-            p = [] # list of peak values, representing absolute amplitude
-            w = [] # list of timestamps for corresponding chunk
+            a = []  # list of waveform data
+            p = []  # list of peak values, representing absolute amplitude
+            w = []  # list of timestamps for corresponding chunk
 
             here = 0  # offset in bytes
             when = data.pts
             last = data.pts + actual_duration
-            logger.debug(f"Processing audio chunk: size={size}, duration={actual_duration}, bpc={bpc}")
-            
+
+            logger.debug(
+                f"Processing audio chunk: size={size}, "
+                f"duration={actual_duration}, bpc={bpc}"
+            )
+
             while True:
                 try:
                     # Extract raw bytes from the buffer
                     # `extract_dup` -> Extracts a copy of at most size bytes the data at offset into newly-allocated memory. (from docs)
                     raw_bytes = data.extract_dup(here, bpc)
-                    
-                    if len(raw_bytes) == 0: # Handling case when chunk is empty - this happens sometimes.
+
+                    if len(raw_bytes) == 0:
+                        # Handling case when chunk is empty - this happens sometimes.
                         logger.debug("Empty audio chunk - breaking")
                         break
-                    
+
                     # Convert to int16 array
                     wave = numpy.frombuffer(raw_bytes, dtype='int16')
                     if len(wave) == 0:
                         logger.debug("Empty wave array after conversion - breaking")
                         break
-                        
+
                     peak = numpy.max(numpy.abs(wave))
                     logger.debug(f"Processed wave chunk: length={len(wave)}, peak={peak}")
 
                 except (ValueError, TypeError) as e:
                     logger.warning(f"Error processing audio data for lip sync: {e}")
                     break
-
                 except Exception as e:
                     logger.error(f"Unexpected error in handoff function: {e}")
                     break
@@ -222,49 +401,11 @@ class Speech(GstSpeechPlayer):
                 a.append(wave)
                 p.append(peak)
                 w.append(when)
-
                 here += bpc
                 when += npc
                 if when < last:
                     continue
                 break
-
-            def poke(pts):
-                success, position = ears.query_position(Gst.Format.TIME)
-                if not success:
-                    logger.debug("Position query failed, using fallback timing")
-
-                    # Fallback: emit one chunk per tick, re-schedule until done
-                    if len(w) > 0:
-                        logger.debug(f"Emitting signals (fallback): wave length={len(a[0])}, peak={p[0]}")
-                        self.emit("wave", a[0])
-                        self.emit("peak", p[0])
-                        del a[0]
-                        del w[0]
-                        del p[0]
-                        # Re-schedule timer if more chunks remain
-                        if len(w) > 0:
-                            GLib.timeout_add(25, poke, pts)
-                        return False
-                    return False
-
-                if len(w) == 0:
-                    return False
-
-                if position < w[0]:
-                    return True
-
-                logger.debug(f"Emitting signals: wave length={len(a[0])}, peak={p[0]}")
-                self.emit("wave", a[0])
-                self.emit("peak", p[0])
-                del a[0]
-                del w[0]
-                del p[0]
-
-                if len(w) > 0:
-                    return True
-
-                return False
 
             # Calculate interval so that all chunks are spread evenly over the audio duration
             total_chunks = len(a)
@@ -281,114 +422,135 @@ class Speech(GstSpeechPlayer):
                 if len(a) > 0:
                     self.emit("wave", a[0])
                     self.emit("peak", p[0])
-                    del a[0]
-                    del p[0]
-                    del w[0]
+                    del a[0], p[0], w[0]
                     if len(a) > 0:
                         GLib.timeout_add(interval_ms, emit_next_chunk)
                     return False
                 return False
 
             # For Kokoro, use time-based emission since position queries will fail while streaming in chunks
-            if KOKORO_AVAILABLE and self.kokoro_pipeline:
+            if KOKORO_AVAILABLE and self.kokoro:
                 GLib.timeout_add(interval_ms, emit_next_chunk)
             else:
+                def poke(pts):
+                    success, position = ears.query_position(Gst.Format.TIME)
+                    if success and position >= w[0]:
+                        self.emit("wave", a[0])
+                        self.emit("peak", p[0])
+                        del a[0], p[0], w[0]
+                    if len(w) > 0:
+                        GLib.timeout_add(25, poke, pts)
+                        return False
+                    return False
                 GLib.timeout_add(25, poke, data.pts)
 
             return True
 
         sink = self.pipeline.get_by_name('sink')
-        sink.props.signal_handoffs = True
-        sink.connect('handoff', handoff)
+        if sink:
+            sink.props.signal_handoffs = True
+            sink.connect('handoff', handoff)
 
-        def gst_message_cb(bus, message):
-            self._was_message = True
-
-            if message.type == Gst.MessageType.WARNING:
-                def check_after_warnings():
-                    if not self._was_message:
-                        self.stop_sound_device()
-                    return True
-
-                logger.debug(message.type)
-                self._was_message = False
-                GLib.timeout_add(500, check_after_warnings)
-
-            elif message.type in (Gst.MessageType.EOS, Gst.MessageType.ERROR):
-                logger.debug(message.type)
-                self.stop_sound_device()
-            return True
-
-        self._was_message = False
         bus = self.pipeline.get_bus()
         bus.add_signal_watch()
+
+        def gst_message_cb(bus, message):
+            if message.type == Gst.MessageType.EOS:
+                logger.debug("GStreamer: End of stream")
+                self.stop_sound_device()
+                self.emit('idle')
+            elif message.type == Gst.MessageType.ERROR:
+                err, debug = message.parse_error()
+                logger.error(f"GStreamer error: {err.message} | dbg: {debug}")
+                self.stop_sound_device()
+            elif message.type == Gst.MessageType.WARNING:
+                err, debug = message.parse_warning()
+                logger.warning(f"GStreamer warn: {err.message} | dbg: {debug}")
+
         bus.connect('message', gst_message_cb)
 
     def _stream_kokoro_audio(self, text, voice):
         """Stream Kokoro audio chunks to the GStreamer pipeline"""
         try:
+            if not self.pipeline:
+                return
+
             # Getting the appsrc element
             appsrc = self.pipeline.get_by_name('kokoro_src')
             if not appsrc:
-                logger.error("Could not find kokoro_src element")
                 return
-            
-            # Set caps for Kokoro audio
-            caps = Gst.Caps.from_string(
-                "audio/x-raw,format=F32LE,layout=interleaved,rate=24000,channels=1"
-            )
-            appsrc.set_property("caps", caps)
 
-            audio_generator = self.kokoro_pipeline(text, voice=voice) # actual audio generation by kokoro
+            lang_map = {
+                'a': 'en-us', 'b': 'en-gb', 'e': 'es',
+                'f': 'fr-fr', 'h': 'hi', 'j': 'ja',
+                'p': 'pt-br', 'z': 'cmn', 'i': 'it'
+            }
+            prefix_char = voice.split('_')[0][0] if '_' in voice else 'a'
+            lang_code = lang_map.get(prefix_char, 'en-us')
+
+            logger.info(f"Generating TTS | Voice: {voice} | Lang: {lang_code}")
+
+            # actual audio generation by kokoro
+            samples, sample_rate = self.kokoro.create(
+                text, voice=voice, speed=1.0, lang=lang_code
+            )
+
+            if samples is None or len(samples) == 0:
+                logger.warning("Kokoro generated empty audio")
+                appsrc.emit("end-of-stream")
+                return
 
             # Stream audio chunks
-            for i, (gs, ps, audio_chunk) in enumerate(audio_generator):
-                # Convert tensor to numpy array then to bytes
-                data_bytes = audio_chunk.numpy().tobytes()
-                
-                # Create GStreamer buffer
-                buf = Gst.Buffer.new_wrapped(data_bytes)
-                
-                # Push buffer to appsrc
-                ret = appsrc.emit("push-buffer", buf)
-                if ret != Gst.FlowReturn.OK:
-                    logger.error(f"Error pushing buffer {i} to GStreamer")
-                    break
-
-            appsrc.emit("end-of-stream") # Signal EOS
+            # Convert tensor to numpy array then to bytes
+            data_bytes = samples.tobytes()
             
+            # Create GStreamer buffer
+            buf = Gst.Buffer.new_wrapped(data_bytes)
+
+            # Only set duration, let GStreamer handle PTS
+            buf.duration = int((len(samples) / 24000) * Gst.SECOND)
+
+            # Push buffer to appsrc
+            appsrc.emit("push-buffer", buf)
+            
+            # Signal EOS
+            appsrc.emit("end-of-stream")
+            logger.info(f"Pushed {len(data_bytes)} bytes successfully.")
+
         except Exception as e:
             # Signalling EOS here as well, but I'm adding error to logs
-            logger.error(f"Error in Kokoro audio streaming: {e}")
-            if appsrc:
-                appsrc.emit("end-of-stream")
+            logger.error(f"Error in Kokoro ONNX generation: {e}")
+            try:
+                if appsrc:
+                    appsrc.emit("end-of-stream")
+            except Exception:
+                pass
 
     def speak(self, status, text):
-        self.make_pipeline()
-        
-        if KOKORO_AVAILABLE and self.kokoro_pipeline:
-            logger.debug('Using Kokoro TTS: voice=%s text=%s' % (self.current_kokoro_voice, text))
-            self.restart_sound_device()
-            self._stream_kokoro_audio(text, self.current_kokoro_voice)
-            
+        use_kokoro = KOKORO_AVAILABLE and (self.kokoro is not None)
+        self.make_pipeline(use_kokoro=use_kokoro)
+
+        if use_kokoro:
+            logger.debug('Using Kokoro ONNX: voice=%s' % self.current_kokoro_voice)
+            # Run TTS generation in a thread to avoid blocking the UI
+            threading.Thread(
+                target=self._stream_kokoro_audio,
+                args=(text, self.current_kokoro_voice),
+                daemon=True
+            ).start()
         else:
             # Fallback to espeak
-            src = self.pipeline.get_by_name('espeak')
-            
-            pitch = int(status.pitch) - 100
-            rate = int(status.rate) - 100
-
-            logger.debug('Using espeak fallback: pitch=%d rate=%d voice=%s text=%s' % (pitch, rate,
-                                                                status.voice.name,
-                                                                text))
-
-            src.props.pitch = pitch
-            src.props.rate = rate
-            src.props.voice = status.voice.name
-            src.props.track = 1
-            src.props.text = text
-
-            self.restart_sound_device()
+            try:
+                if self.pipeline:
+                    src = self.pipeline.get_by_name('espeak')
+                    if src:
+                        src.props.pitch = status.pitch
+                        src.props.rate = status.rate
+                        src.props.voice = status.voice
+                        src.props.track = 2
+                        src.props.text = text
+            except Exception as e:
+                logger.error(f"Espeak fallback failed: {e}")
 
 
 _speech = None
@@ -396,8 +558,6 @@ _speech = None
 
 def get_speech():
     global _speech
-
     if _speech is None:
         _speech = Speech()
-
     return _speech


### PR DESCRIPTION
Following up on our discussions regarding backend optimization and language support, this PR completely migrates the activity off PyTorch and onto Kokoro-ONNX, while implementing the required multilingual routing.

### What This PR Does:
1. **Zero PyTorch Dependency:** Replaced the heavy `kokoro` (PyTorch) pipeline with `kokoro-onnx`. This drastically reduces the RAM footprint and removes ~1GB of disk dependencies. Updated `requirements.txt` accordingly.
2. **Multilingual G2P Mapping:** Added a dynamic routing system in `speech.py` that parses the voice prefix (e.g., `ef_`, `ff_`, `im_`) and correctly maps it to the corresponding ISO language code (`es`, `fr-fr`, `it`) for the backend. Non-English languages now pronounce words natively.
3. **GStreamer Pipeline Overhaul:** Fixed the pipeline audio conversions. It now explicitly sets `time` formats and converts `F32LE` 24kHz audio down to standard hardware-compatible formats, ensuring the `autoaudiosink` doesn't fail silently.
4. **Crash Fixes:** - Removed the old `.pt` file downloading logic from `activity.py` which was causing crashes upon selecting voices.
   - Added a safety check to `_try_llm_response` so the activity falls back to the SLM gracefully instead of crashing with a `bool` error if the LLM API times out.

### How to Test Locally:
1. Ensure your `models` folder contains `kokoro-v1.0.fp16.onnx` and `voices-v1.0.bin`.
2. Run the activity: `sugar-activity3`.
3. Select a Spanish voice (e.g., `ef_dora`) and type: *"Hola, ¿cómo estás?"* 4. Select a French voice (e.g., `ff_siwis`) and type: *"Bonjour le monde."*

*(Note: You will see `phonemizer` warnings in the console—this is expected from the backend processing non-English phonemes).*

I'd love your feedback on the GStreamer pipeline changes!