### PR TITLE
Handle missing API_KEY.txt safely to prevent import crash

### DIFF
--- a/LLM.py
+++ b/LLM.py
@@ -5,8 +5,12 @@ import logging
 
 #TODO: Dont hard code these, need to see how sugar as a whole manages API Keys
 API_URL = "https://ai.sugarlabs.org/ask-llm-prompted"
-with open("API_KEY.txt", "r") as f:
-    API_KEY = f.read().strip()
+try:
+    with open("API_KEY.txt", "r") as f:
+        API_KEY = f.read().strip()
+except OSError:
+    logging.error("Missing API_KEY.txt file.")
+    API_KEY = None
 
 DEFAULT_PROMPT = "You are a friendly teacher named Jane who is 28 years old. You teach 10 year old children. Always give helpful, educational responses in simple words that children can understand. Keep your answers between 20-40 words. Be encouraging and enthusiastic but never use emojis(ever). If you notice spelling mistakes, gently correct them. Stay focused on the topic and give relevant answers."
 
@@ -20,6 +24,10 @@ def is_connected():
         return False
 
 def ask_llm_prompted(question, custom_prompt = DEFAULT_PROMPT, timeout=120, max_length=200):
+    if API_KEY is None:
+        logging.error("Missing API key file: API_KEY.txt")
+        return False
+    
     if not is_connected():
         return False
 


### PR DESCRIPTION
Fix missing error handling in LLM.py when API_KEY.txt is absent.

Problem:
LLM.py attempted to read API_KEY.txt at import time without handling missing files.
If the file was absent, the module crashed with FileNotFoundError during import.

Solution:
- Wrapped API key loading in try/except
- Set API_KEY to None if file is missing
- Added guard in ask_llm_prompted to return False when API key is unavailable

This prevents import-time crashes and maintains consistent failure behavior.