### PR TITLE
Fix crash in get_default_voice when default voice is None

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -78,12 +78,19 @@ def _get_age():
 
 def get_default_voice():
     default_voice = voice.defaultVoice()
-    if default_voice.friendlyname not in BOTS:
-        return voice.allVoices()[_('English')]
-    else:
+    if default_voice is not None and default_voice.friendlyname in BOTS:
         return default_voice
 
+    voices = voice.allVoices()
+    english_voice = voices.get(_('English'))
+    if english_voice is not None:
+        return english_voice
 
+    if default_voice is not None:
+        return default_voice
+
+    return next(iter(voices.values()), None)
+    
 def respond(text):
     if _kernel is not None:
         text = _kernel.respond(text)


### PR DESCRIPTION
Problem:
- get_default_voice() accessed default_voice.friendlyname without
  checking if default_voice was None, which could cause an
  AttributeError.
- The code also directly indexed allVoices()[_('English')] without
  verifying that the key exists, which could raise a KeyError when
  an English voice is not available.

Fix:
- Added a None check before accessing default_voice.friendlyname
- Replaced direct dictionary access with dict.get() for safer
  English voice lookup
- Added fallback logic to return a valid voice when possible
  (English → default voice → first available voice)