### PR TITLE
Fix logic bug: == used instead of = in robot mode voice selection

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -1467,7 +1467,7 @@ class SpeakActivity(activity.Activity):
             new_voice = None
             for name in list(brain.BOTS.keys()):
                 if self._current_voice[0].short_name == name:
-                    new_voice == self._current_voice[0]
+                    new_voice = self._current_voice[0]
                     break
             if new_voice is None:
                 new_voice = brain.get_default_voice()


### PR DESCRIPTION
Bug:
Line 1470 used `==` (comparison) instead of `=` (assignment).

As a result, `new_voice` was never assigned from the current
voice even when a match was found. This caused the code to always
fall back to `brain.get_default_voice()`.

Fix:
Replace the incorrect comparison operator with assignment so
`new_voice` is correctly set when a matching voice is found.