### PR TITLE
Fix duplicate entries in kokoro_voices list

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -62,7 +62,7 @@ class Speech(GstSpeechPlayer):
         self.kokoro_voices = [
             'af_heart', 'af_alloy', 'af_aoede', 'af_bella', 'af_jessica', 'af_kore', 'af_nicole',
             'af_nova', 'af_river', 'af_sarah', 'af_sky','am_adam', 'am_echo', 'am_eric', 'am_fenrir',
-            'am_liam', 'am_michael', 'am_onyx'
+            'am_liam', 'am_michael', 'am_onyx',
             'am_puck', 'am_santa', 'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily', 'bm_daniel',
             'bm_fable', 'bm_george', 'bm_lewis', 'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro',
             'jm_kumo', 'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi', 'zm_yunjian',

--- a/speech.py
+++ b/speech.py
@@ -62,7 +62,7 @@ class Speech(GstSpeechPlayer):
         self.kokoro_voices = [
             'af_heart', 'af_alloy', 'af_aoede', 'af_bella', 'af_jessica', 'af_kore', 'af_nicole',
             'af_nova', 'af_river', 'af_sarah', 'af_sky','am_adam', 'am_echo', 'am_eric', 'am_fenrir',
-            'am_adam', 'am_echo', 'am_eric', 'am_fenrir', 'am_liam', 'am_michael', 'am_onyx',
+            'am_liam', 'am_michael', 'am_onyx'
             'am_puck', 'am_santa', 'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily', 'bm_daniel',
             'bm_fable', 'bm_george', 'bm_lewis', 'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro',
             'jm_kumo', 'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi', 'zm_yunjian',


### PR DESCRIPTION
Fixes issue #31 

This PR removes duplicate voice entries from the `kokoro_voices` list in `speech.py`.

During a review of the voice list, I noticed that several voices appeared more than once. 
These duplicates can result in repeated options in the voice selection UI.

This change ensures that each voice appears only once in the list, making the voice 
selection cleaner and avoiding redundant entries.