### PR TITLE
Ensure kokoro_voices list contains unique entries

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -70,6 +70,9 @@ class Speech(GstSpeechPlayer):
             'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
             'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
         ]
+        # Remove duplicate voice entries while preserving order
+        self.kokoro_voices = list(dict.fromkeys(self.kokoro_voices))
+
         self.current_kokoro_voice = 'af_heart'
 
         self._cb = {}

--- a/voice.py
+++ b/voice.py
@@ -84,11 +84,17 @@ class Voice:
         self.language = language
         self.name = name
         friendlyname = name
-        friendlyname = friendlyname.replace('-test', '')
-        friendlyname = friendlyname.replace('_test', '')
-        friendlyname = friendlyname.replace('en-', '')
-        friendlyname = friendlyname.replace('english-wisper', 'whisper')
-        friendlyname = friendlyname.replace('english-us', 'us')
+
+        replacements = {
+            '-test': '',
+            '_test': '',
+            'en-': '',
+            'english-whisper': 'whisper',
+            'english-us': 'us'
+        }
+
+        for old, new in replacements.items():
+            friendlyname = friendlyname.replace(old, new)
 
         friendlynameRP = name  # friendlyname for RP
         friendlynameRP = friendlynameRP.replace('english_rp', 'rp')


### PR DESCRIPTION
While exploring speech.py I noticed that the kokoro_voices list contains duplicate
entries such as am_adam, am_echo, am_eric, and am_fenrir.

This change ensures duplicates are automatically removed while preserving the
original order using:

list(dict.fromkeys(self.kokoro_voices))

This prevents duplicate voices from appearing multiple times in the voice
selection UI.