### PR TITLE
Fix generation mode changes not affecting inference parameters

### DIFF
--- a/GenAI/gguf_inference.py
+++ b/GenAI/gguf_inference.py
@@ -60,7 +60,11 @@ class GGUFInference:
             verbose=verbose
         )
 
-        self.generation_params = {
+        self.generation_params = self._build_generation_params()
+
+    def _build_generation_params(self) -> Dict:
+        """Build llama.cpp generation parameters from current settings."""
+        return {    
             "max_tokens": self.generation_settings["max_tokens"],
             "temperature": self.generation_settings["temperature"],
             "top_p": self.generation_settings["top_p"],
@@ -96,7 +100,8 @@ class GGUFInference:
     
     def set_generation_mode(self, mode: int):
         self.generation_settings = self._get_generation_settings(mode)
-    
+        self.generation_params = self._build_generation_params()
+        
     def _contains_profanity(self, text: str) -> bool:
         """
         Check if the given text contains any profanity from the blacklist (whole word match only).


### PR DESCRIPTION
## Summary

Fix a runtime issue where `set_generation_mode()` updated
`generation_settings` but did not refresh the `generation_params`
used during model inference.

Previously, `generation_params` was only built in `__init__`.
If `set_generation_mode()` was called later, the parameters passed
to llama.cpp could remain stale and ignore the requested generation mode.

## Fix

Introduced a helper method `_build_generation_params()` and rebuild
`generation_params` whenever the generation mode changes.

## Impact

This code path is used in `activity.py` where:

load_gguf_model() → set_generation_mode(3) → ask_question()

Before this fix, changing the generation mode did not actually affect
the inference parameters. After this patch, generation parameters are
updated correctly whenever the mode changes.