### PR TITLE
feat: auto-detect Sugar profile language for Kokoro TTSFeat/sugar locale tts integration

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -28,6 +28,12 @@ logger = logging.getLogger('speak')
 
 from sugar3.speech import GstSpeechPlayer
 
+try:
+    from sugar3 import profile as sugar_profile
+    SUGAR_AVAILABLE = True
+except ImportError:
+    SUGAR_AVAILABLE = False
+
 # Kokoro TTS imports
 try:
     from kokoro import KPipeline
@@ -74,13 +80,46 @@ class Speech(GstSpeechPlayer):
         self.kokoro_voices = list(dict.fromkeys(self.kokoro_voices))
 
         self.current_kokoro_voice = 'af_heart'
+        self.kokoro_pipeline = KPipeline(
+           lang_code=self._get_sugar_lang_code()
+        )
 
         self._cb = {}
         for cb in ['peak', 'wave', 'idle']:
             self._cb[cb] = None
-
+            
+    def _get_sugar_lang_code(self):
+        """Read Sugar profile language and return
+        the corresponding Kokoro lang_code.
+        Falls back to 'a' (English) if unavailable."""
+        SUGAR_TO_KOKORO = {
+            'en': 'a', 'hi': 'h', 'ar': 'ar',
+            'zh': 'z', 'fr': 'f', 'pt': 'p',
+            'es': 'e', 'it': 'i',
+        }
+        try:
+            if SUGAR_AVAILABLE:
+                lang = sugar_profile.get_profile().get(
+                    'country', 'en_US'
+                )
+                lang_code = lang.split('_')[0].lower()
+                kokoro_code = SUGAR_TO_KOKORO.get(
+                    lang_code, 'a'
+                )
+                logger.debug(
+                    'Sugar locale: %s → Kokoro: %s',
+                    lang_code, kokoro_code
+                )
+                return kokoro_code
+        except Exception as e:
+            logger.warning(
+                'Could not read Sugar profile: %s', e
+            )
+        return 'a'
     def setup_kokoro(self):
-        self.kokoro_pipeline = KPipeline(lang_code='a')
+        self.kokoro_pipeline = KPipeline(
+           lang_code=self._get_sugar_lang_code()
+        )
 
     def disconnect_all(self):
         for cb in ['peak', 'wave', 'idle']:

--- a/speech.py
+++ b/speech.py
@@ -70,6 +70,9 @@ class Speech(GstSpeechPlayer):
             'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
             'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
         ]
+        # Remove duplicate voice entries while preserving order
+        self.kokoro_voices = list(dict.fromkeys(self.kokoro_voices))
+
         self.current_kokoro_voice = 'af_heart'
 
         self._cb = {}

--- a/voice.py
+++ b/voice.py
@@ -84,11 +84,17 @@ class Voice:
         self.language = language
         self.name = name
         friendlyname = name
-        friendlyname = friendlyname.replace('-test', '')
-        friendlyname = friendlyname.replace('_test', '')
-        friendlyname = friendlyname.replace('en-', '')
-        friendlyname = friendlyname.replace('english-wisper', 'whisper')
-        friendlyname = friendlyname.replace('english-us', 'us')
+
+        replacements = {
+            '-test': '',
+            '_test': '',
+            'en-': '',
+            'english-whisper': 'whisper',
+            'english-us': 'us'
+        }
+
+        for old, new in replacements.items():
+            friendlyname = friendlyname.replace(old, new)
 
         friendlynameRP = name  # friendlyname for RP
         friendlynameRP = friendlynameRP.replace('english_rp', 'rp')


### PR DESCRIPTION
## Summary

Previously, the Kokoro TTS pipeline was initialized 
with a hardcoded English lang_code ('a') regardless 
of the user's language preference.

This PR integrates with Sugar's existing locale 
detection system to automatically set the TTS 
language based on the user's Sugar profile language 
on startup.

## Changes in speech.py

- Added optional import of `sugar3.profile` with 
  graceful fallback if unavailable
- Added `_get_sugar_lang_code()` method that reads 
  the user's Sugar profile locale and maps it to 
  the appropriate Kokoro lang_code
- Updated `__init__` and `setup_kokoro` to use 
  `_get_sugar_lang_code()` instead of hardcoded 'a'

## Supported languages

| Sugar locale | Kokoro lang_code |
|---|---|
| en | a (English) |
| hi | h (Hindi) |
| ar | ar (Arabic) |
| zh | z (Chinese) |
| fr | f (French) |
| pt | p (Portuguese) |
| es | e (Spanish) |
| it | i (Italian) |

## Notes

- Falls back to English safely if Sugar profile 
  is unavailable or locale is not supported
- Addresses locale integration suggestion raised 
  in PR #22 review by Naitik120gupta
- Closes #27