### PR TITLE
Feat: multilingual kokoro poc

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -313,11 +313,18 @@ class SpeakActivity(activity.Activity):
         toolbox.toolbar.insert(self._persona_button, -1)
 
 
-        self._kokoro_button = ToolButton('module-language')
-        self._kokoro_button.set_tooltip(_('Choose Kokoro voice:'))
-        self._make_kokoro()
-        self._kokoro_button.connect('clicked', self._face_palette_cb)
-        toolbox.toolbar.insert(self._kokoro_button, -1)
+        # Language selector for Kokoro-backed TTS.
+        self._lang_combo = Gtk.ComboBoxText()
+        self._lang_combo.append('en', _('English'))
+        self._lang_combo.append('es', _('Spanish'))
+        self._lang_combo.append('fr', _('French'))
+        self._lang_combo.append('hi', _('Hindi'))
+        self._lang_combo.set_active_id('en')
+        self._lang_combo.connect('changed', self._language_changed_cb)
+        lang_item = Gtk.ToolItem()
+        lang_item.add(self._lang_combo)
+        lang_item.show_all()
+        toolbox.toolbar.insert(lang_item, -1)
 
         self._face_button = ToolbarButton(
             page=self._make_face_bar(),
@@ -361,6 +368,10 @@ class SpeakActivity(activity.Activity):
         else:
             # we are creating the activity
             self.connect('shared', self._shared_cb)
+
+        # Apply initial language to speech backend.
+        self._apply_language_to_speech('en')
+
 
     def _toolbar_expanded(self):
         if self._activity_button.is_expanded():
@@ -419,6 +430,19 @@ class SpeakActivity(activity.Activity):
                                        % self.owner.props.nick)
         self._set_idle_phrase(speak=False)
         self._first_time = False
+
+    def _apply_language_to_speech(self, lang_id):
+        try:
+            speech.get_speech().set_language(lang_id)
+        except AttributeError:
+            # Older speech backends without multilingual support.
+            pass
+
+    def _language_changed_cb(self, combo):
+        lang_id = combo.get_active_id()
+        if not lang_id:
+            return
+        self._apply_language_to_speech(lang_id)
 
     def read_file(self, file_path):
         self._cfg = json.loads(open(file_path, 'r').read())
@@ -795,97 +819,6 @@ class SpeakActivity(activity.Activity):
 
         facebar.show_all()
         return facebar
-
-    def _make_kokoro(self):
-        self._kokoro_voice_evboxes = {}
-        self._kokoro_voice_box = Gtk.VBox()
-
-        # Add heading for DEFAULT VOICES
-        default_heading = Gtk.Label()
-        default_heading.set_markup('<b>DEFAULT VOICES</b>')
-        default_heading.set_justify(Gtk.Justification.CENTER)
-        default_heading.set_alignment(0.5, 0)
-        self._kokoro_voice_box.pack_start(default_heading, False, False, style.DEFAULT_PADDING)
-        default_heading.show()
-
-        # Arrange default voices in 3 columns
-        default_voices = speech.get_speech().get_default_kokoro_voices()
-        current_voice = speech.get_speech().current_kokoro_voice
-        default_vboxes = [Gtk.VBox(), Gtk.VBox(), Gtk.VBox()]
-        count = len(default_voices)
-        for i, voice_name in enumerate(default_voices):
-            label = Gtk.Label()
-            label.set_use_markup(True)
-            label.set_justify(Gtk.Justification.LEFT)
-            label.set_markup('<span size="large">%s</span>' % voice_name)
-            alignment = Gtk.Alignment.new(0, 0, 0, 0)
-            alignment.add(label)
-            label.show()
-            evbox = Gtk.EventBox()
-            self._kokoro_voice_evboxes[voice_name] = evbox
-            evbox.connect('button-press-event', self._kokoro_voice_changed_event_cb, voice_name)
-            if voice_name == current_voice:
-                evbox.modify_bg(0, style.COLOR_BUTTON_GREY.get_gdk_color())
-            evbox.add(alignment)
-            alignment.show()
-            if i < count // 3:
-                default_vboxes[0].pack_start(evbox, True, True, 0)
-            elif i < count // 3 * 2:
-                default_vboxes[1].pack_start(evbox, True, True, 0)
-            else:
-                default_vboxes[2].pack_start(evbox, True, True, 0)
-            evbox.show()
-        default_hbox = Gtk.HBox()
-        default_hbox.pack_start(default_vboxes[0], True, True, style.DEFAULT_PADDING)
-        default_hbox.pack_start(default_vboxes[1], True, True, style.DEFAULT_PADDING)
-        default_hbox.pack_start(default_vboxes[2], True, True, style.DEFAULT_PADDING)
-        self._kokoro_voice_box.pack_start(default_hbox, False, False, style.DEFAULT_PADDING)
-        default_hbox.show_all()
-
-        # Add heading for Add-on Voices
-        addon_heading = Gtk.Label()
-        addon_heading.set_markup('<b>ADD-ON VOICES</b>')
-        addon_heading.set_justify(Gtk.Justification.CENTER)
-        addon_heading.set_alignment(0.5, 0)
-        self._kokoro_voice_box.pack_start(addon_heading, False, False, style.DEFAULT_PADDING)
-        addon_heading.show()
-
-        # Arrange add-on voices in 3 columns
-        addon_voices = speech.get_speech().get_addon_kokoro_voices()
-        addon_vboxes = [Gtk.VBox(), Gtk.VBox(), Gtk.VBox()]
-        count = len(addon_voices)
-        for i, voice_name in enumerate(addon_voices):
-            label = Gtk.Label()
-            label.set_use_markup(True)
-            label.set_justify(Gtk.Justification.LEFT)
-            label.set_markup('<span size="large">%s</span>' % voice_name)
-            alignment = Gtk.Alignment.new(0, 0, 0, 0)
-            alignment.add(label)
-            label.show()
-            evbox = Gtk.EventBox()
-            self._kokoro_voice_evboxes[voice_name] = evbox
-            evbox.connect('button-press-event', self._kokoro_voice_changed_event_cb, voice_name)
-            if voice_name == current_voice:
-                evbox.modify_bg(0, style.COLOR_BUTTON_GREY.get_gdk_color())
-            evbox.add(alignment)
-            alignment.show()
-            if i < count // 3:
-                addon_vboxes[0].pack_start(evbox, True, True, 0)
-            elif i < count // 3 * 2:
-                addon_vboxes[1].pack_start(evbox, True, True, 0)
-            else:
-                addon_vboxes[2].pack_start(evbox, True, True, 0)
-            evbox.show()
-        addon_hbox = Gtk.HBox()
-        addon_hbox.pack_start(addon_vboxes[0], True, True, style.DEFAULT_PADDING)
-        addon_hbox.pack_start(addon_vboxes[1], True, True, style.DEFAULT_PADDING)
-        addon_hbox.pack_start(addon_vboxes[2], True, True, style.DEFAULT_PADDING)
-        self._kokoro_voice_box.pack_start(addon_hbox, False, False, style.DEFAULT_PADDING)
-        addon_hbox.show_all()
-
-        self._kokoro_palette = self._kokoro_button.get_palette()
-        self._kokoro_palette.set_content(self._kokoro_voice_box)
-        self._kokoro_voice_box.show_all()
 
     def _make_personas(self):
         self._persona_evboxes = {}

--- a/activity.py
+++ b/activity.py
@@ -882,7 +882,10 @@ class SpeakActivity(activity.Activity):
         self._persona_box.show_all()
         
     def _kokoro_voice_changed_event_cb(self, widget, event, voice_name):
-        # Show info label(Indication of voice changing) upon click
+        if not hasattr(self, '_kokoro_voice_box') or \
+                not hasattr(self, '_kokoro_voice_evboxes'):
+            return
+
         info_label = Gtk.Label()
         info_label.set_markup('<span foreground="blue" size="large">%s</span>' % _('Please wait...'))
         self._kokoro_voice_box.pack_start(info_label, False, False, style.DEFAULT_PADDING)
@@ -920,11 +923,13 @@ class SpeakActivity(activity.Activity):
             if is_local:
                 message = _('Changing voice, please wait')
                 info_label.set_markup('<span foreground="green" size="large">%s</span>' % message)
-                # Now update UI for voice selection
-                for old_name, evbox in self._kokoro_voice_evboxes.items():
-                    if old_name == speech.get_speech().current_kokoro_voice:
-                        evbox.modify_bg(0, style.COLOR_BLACK.get_gdk_color())
-                self._kokoro_voice_evboxes[voice_name].modify_bg(0, style.COLOR_BUTTON_GREY.get_gdk_color())
+                if self._kokoro_voice_evboxes:
+                    for old_name, evbox in self._kokoro_voice_evboxes.items():
+                        if old_name == speech.get_speech().current_kokoro_voice:
+                            evbox.modify_bg(0, style.COLOR_BLACK.get_gdk_color())
+                    if voice_name in self._kokoro_voice_evboxes:
+                        self._kokoro_voice_evboxes[voice_name].modify_bg(
+                            0, style.COLOR_BUTTON_GREY.get_gdk_color())
 
                 # Actually set the voice (may trigger download from Hugging Face Hub)
                 speech.get_speech().set_kokoro_voice(voice_name)
@@ -934,7 +939,8 @@ class SpeakActivity(activity.Activity):
                 Gtk.main_iteration()
 
             def _remove_info_label():
-                self._kokoro_voice_box.remove(info_label)
+                if hasattr(self, '_kokoro_voice_box'):
+                    self._kokoro_voice_box.remove(info_label)
             GLib.timeout_add(3000, _remove_info_label)
 
         GLib.idle_add(async_check_and_update)
@@ -954,22 +960,18 @@ class SpeakActivity(activity.Activity):
         # Set current persona
         self._current_persona = persona_name
 
-        # Get the persona's voice and set it (using Kokoro voices)
         persona_voice_name = self._personas[persona_name]['voice']
 
-        # Update Kokoro voice selection visually
         current_kokoro_voice = speech.get_speech().current_kokoro_voice
-        if self._kokoro_voice_evboxes.get(persona_voice_name, False):
-            # Clear old Kokoro voice selection
+        if hasattr(self, '_kokoro_voice_evboxes') and \
+                self._kokoro_voice_evboxes.get(persona_voice_name, False):
             if self._kokoro_voice_evboxes.get(current_kokoro_voice, False):
                 self._kokoro_voice_evboxes[current_kokoro_voice].modify_bg(
                     0, style.COLOR_BLACK.get_gdk_color())
 
-            # Highlight new Kokoro voice selection
             self._kokoro_voice_evboxes[persona_voice_name].modify_bg(
                 0, style.COLOR_BUTTON_GREY.get_gdk_color())
-            
-            # Set the Kokoro voice
+
             speech.get_speech().set_kokoro_voice(persona_voice_name)
 
         self.face.say_notification(_('Persona changed to %s') % persona_name)

--- a/speech.py
+++ b/speech.py
@@ -36,6 +36,32 @@ except ImportError:
     KOKORO_AVAILABLE = False
     logger.warning("Kokoro not available, falling back to espeak")
 
+KOKORO_LANG_MAP = {
+    'en': 'a',      # American English
+    'en_GB': 'b',   # British English
+    'es': 'e',      # Spanish
+    'fr': 'f',      # French
+    'hi': 'h',      # Hindi
+    'pt': 'p',      # Brazilian Portuguese (default)
+    'pt_BR': 'p',   # Brazilian Portuguese
+    'zh': 'z',      # Mandarin Chinese
+    'zh_CN': 'z',   # Mandarin Chinese (Simplified)
+}
+
+DEFAULT_LANG = 'en'
+
+DEFAULT_KOKORO_VOICE_BY_LANG = {
+    'en': 'af_heart',
+    'en_GB': 'bf_emma',
+    'es': 'ef_dora',
+    'fr': 'ff_siwis',
+    'hi': 'hf_alpha',
+    'pt': 'pf_dora',
+    'pt_BR': 'pf_dora',
+    'zh': 'zf_xiaoxiao',
+    'zh_CN': 'zf_xiaoxiao',
+}
+
 PITCH_MIN = 0
 PITCH_MAX = 200
 RATE_MIN = 0
@@ -52,7 +78,10 @@ class Speech(GstSpeechPlayer):
     def __init__(self):
         GstSpeechPlayer.__init__(self)
         self.pipeline = None
-        
+
+        # Logical language (locale-like; e.g. 'en', 'es', 'fr', 'hi')
+        self.current_lang = DEFAULT_LANG
+
         # Initialize Kokoro pipeline if available
         self.kokoro_pipeline = None
         if KOKORO_AVAILABLE:
@@ -70,14 +99,46 @@ class Speech(GstSpeechPlayer):
             'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
             'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
         ]
-        self.current_kokoro_voice = 'af_heart'
+        self.current_kokoro_voice = DEFAULT_KOKORO_VOICE_BY_LANG.get(
+            self.current_lang, 'af_heart'
+        )
 
         self._cb = {}
         for cb in ['peak', 'wave', 'idle']:
             self._cb[cb] = None
 
+    def _get_kokoro_lang_code(self, locale_code):
+        """Return Kokoro lang_code for the given locale-like code."""
+        return KOKORO_LANG_MAP.get(locale_code, KOKORO_LANG_MAP[DEFAULT_LANG])
+
     def setup_kokoro(self):
-        self.kokoro_pipeline = KPipeline(lang_code='a')
+        """Initial Kokoro pipeline setup using the current language."""
+        lang_code = self._get_kokoro_lang_code(self.current_lang)
+        self.kokoro_pipeline = KPipeline(lang_code=lang_code)
+
+    def set_language(self, locale_code):
+        """
+        Update the logical language for TTS and reconfigure Kokoro.
+
+        Intended to be called from the Activity UI when the user selects a
+        language; we accept Sugar-style locale codes (e.g. 'es', 'fr',
+        'hi', 'pt_BR') and map them to Kokoro's internal lang_code.
+        """
+        self.current_lang = locale_code or DEFAULT_LANG
+
+        if KOKORO_AVAILABLE:
+            lang_code = self._get_kokoro_lang_code(self.current_lang)
+            try:
+                self.kokoro_pipeline = KPipeline(lang_code=lang_code)
+                logger.debug("Reconfigured Kokoro for lang=%s (code=%s)",
+                             self.current_lang, lang_code)
+            except Exception as e:
+                logger.error("Failed to reconfigure Kokoro for lang=%s: %s",
+                             self.current_lang, e)
+
+        default_voice = DEFAULT_KOKORO_VOICE_BY_LANG.get(self.current_lang)
+        if default_voice:
+            self.current_kokoro_voice = default_voice
 
     def disconnect_all(self):
         for cb in ['peak', 'wave', 'idle']:

--- a/speech.py
+++ b/speech.py
@@ -82,6 +82,8 @@ class Speech(GstSpeechPlayer):
         # Logical language (locale-like; e.g. 'en', 'es', 'fr', 'hi')
         self.current_lang = DEFAULT_LANG
 
+        self._kokoro_lock = threading.Lock()
+
         # Initialize Kokoro pipeline if available
         self.kokoro_pipeline = None
         if KOKORO_AVAILABLE:
@@ -114,7 +116,8 @@ class Speech(GstSpeechPlayer):
     def setup_kokoro(self):
         """Initial Kokoro pipeline setup using the current language."""
         lang_code = self._get_kokoro_lang_code(self.current_lang)
-        self.kokoro_pipeline = KPipeline(lang_code=lang_code)
+        with self._kokoro_lock:
+            self.kokoro_pipeline = KPipeline(lang_code=lang_code)
 
     def set_language(self, locale_code):
         """
@@ -129,16 +132,18 @@ class Speech(GstSpeechPlayer):
         if KOKORO_AVAILABLE:
             lang_code = self._get_kokoro_lang_code(self.current_lang)
             try:
-                self.kokoro_pipeline = KPipeline(lang_code=lang_code)
+                with self._kokoro_lock:
+                    self.kokoro_pipeline = KPipeline(lang_code=lang_code)
                 logger.debug("Reconfigured Kokoro for lang=%s (code=%s)",
                              self.current_lang, lang_code)
             except Exception as e:
                 logger.error("Failed to reconfigure Kokoro for lang=%s: %s",
                              self.current_lang, e)
 
-        default_voice = DEFAULT_KOKORO_VOICE_BY_LANG.get(self.current_lang)
-        if default_voice:
-            self.current_kokoro_voice = default_voice
+        self.current_kokoro_voice = DEFAULT_KOKORO_VOICE_BY_LANG.get(
+            self.current_lang,
+            DEFAULT_KOKORO_VOICE_BY_LANG[DEFAULT_LANG],
+        )
 
     def disconnect_all(self):
         for cb in ['peak', 'wave', 'idle']:
@@ -426,30 +431,35 @@ class Speech(GstSpeechPlayer):
 
     def speak(self, status, text):
         self.make_pipeline()
-        
-        if KOKORO_AVAILABLE and self.kokoro_pipeline:
-            logger.debug('Using Kokoro TTS: voice=%s text=%s' % (self.current_kokoro_voice, text))
+
+        use_kokoro = False
+        if KOKORO_AVAILABLE:
+            with self._kokoro_lock:
+                if self.kokoro_pipeline:
+                    use_kokoro = True
+
+        if use_kokoro:
+            logger.debug('Using Kokoro TTS: voice=%s text=%s',
+                         self.current_kokoro_voice, text)
             self.restart_sound_device()
             self._stream_kokoro_audio(text, self.current_kokoro_voice)
-            
-        else:
-            # Fallback to espeak
-            src = self.pipeline.get_by_name('espeak')
-            
-            pitch = int(status.pitch) - 100
-            rate = int(status.rate) - 100
+            return
 
-            logger.debug('Using espeak fallback: pitch=%d rate=%d voice=%s text=%s' % (pitch, rate,
-                                                                status.voice.name,
-                                                                text))
+        src = self.pipeline.get_by_name('espeak')
 
-            src.props.pitch = pitch
-            src.props.rate = rate
-            src.props.voice = status.voice.name
-            src.props.track = 1
-            src.props.text = text
+        pitch = int(status.pitch) - 100
+        rate = int(status.rate) - 100
 
-            self.restart_sound_device()
+        logger.debug('Using espeak fallback: pitch=%d rate=%d voice=%s text=%s',
+                     pitch, rate, status.voice.name, text)
+
+        src.props.pitch = pitch
+        src.props.rate = rate
+        src.props.voice = status.voice.name
+        src.props.track = 1
+        src.props.text = text
+
+        self.restart_sound_device()
 
 
 _speech = None


### PR DESCRIPTION
# Title

feat: add multilingual Kokoro TTS and language selector

# Summary

- Add multilingual Kokoro support by mapping Sugar-style locales to Kokoro lang_codes and default voices.
- Expose a language selector in the toolbar so users can switch TTS language at runtime (EN/ES/FR/HI for this POC).
- Harden Kokoro UI + pipeline handling so missing widgets or concurrent reconfiguration can’t crash the activity.

# What this PR changes

- `speech.py` : Adds locale  Kokoro lang_code and default-voice maps, a current_lang field, a lock-protected Kokoro pipeline (setup_kokoro, set_language, speak), and a set_language(locale_code) API that always sets a safe default voice and falls back to espeak when Kokoro isn’t usable.

- `activity.py` : Replaces the old Kokoro palette button with a toolbar language dropdown (EN/ES/FR/HI) wired to speech.get_speech().set_language(...), removes _make_kokoro, and makes Kokoro-related callbacks no-op safely when the old Kokoro UI elements are missing.