### PR TITLE
feat: add LRU audio cache for Kokoro TTS pipeline

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -318,6 +318,11 @@ class SpeakActivity(activity.Activity):
         self._make_kokoro()
         self._kokoro_button.connect('clicked', self._face_palette_cb)
         toolbox.toolbar.insert(self._kokoro_button, -1)
+        self._language_button = ToolButton('module-language')
+        self._language_button.set_tooltip(_('Choose language:'))
+        self._make_language_selector()
+        self._language_button.connect('clicked', self._face_palette_cb)
+        toolbox.toolbar.insert(self._language_button, -1)
 
         self._face_button = ToolbarButton(
             page=self._make_face_bar(),
@@ -795,6 +800,87 @@ class SpeakActivity(activity.Activity):
 
         facebar.show_all()
         return facebar
+    
+    def _language_changed_event_cb(self, widget, event, lang_code):
+    """Handle language selection change."""
+    current_lang = speech.get_speech().current_language
+
+    # Clear old highlight
+    if current_lang in self._language_evboxes:
+        self._language_evboxes[current_lang].modify_bg(
+            0, style.COLOR_BLACK.get_gdk_color())
+
+    # Highlight new selection
+    self._language_evboxes[lang_code].modify_bg(
+        0, style.COLOR_BUTTON_GREY.get_gdk_color())
+
+    # Actually change the language
+    speech.get_speech().set_language(lang_code)
+
+    # Update the indicator label
+    lang_name = speech.LANGUAGE_NAMES.get(lang_code, lang_code)
+    self._language_indicator.set_markup(
+        '<i>Current: %s</i>' % lang_name)
+
+    self.face.say_notification(_('Language changed to %s') % lang_name)
+    
+    def _make_language_selector(self):
+    self._language_evboxes = {}
+    self._language_box = Gtk.VBox()
+
+    # Heading
+    heading = Gtk.Label()
+    heading.set_markup('<b>CHOOSE LANGUAGE</b>')
+    heading.set_justify(Gtk.Justification.CENTER)
+    heading.set_alignment(0.5, 0)
+    self._language_box.pack_start(
+        heading, False, False, style.DEFAULT_PADDING)
+    heading.show()
+
+    # Current language indicator
+    self._language_indicator = Gtk.Label()
+    current_lang = speech.get_speech().current_language
+    current_name = speech.LANGUAGE_NAMES.get(current_lang, current_lang)
+    self._language_indicator.set_markup(
+        '<i>Current: %s</i>' % current_name)
+    self._language_box.pack_start(
+        self._language_indicator, False, False, style.DEFAULT_PADDING)
+    self._language_indicator.show()
+
+    # Language list
+    languages = speech.get_speech().get_available_languages()
+    for lang_code in languages:
+        lang_name = speech.LANGUAGE_NAMES.get(lang_code, lang_code)
+
+        label = Gtk.Label()
+        label.set_use_markup(True)
+        label.set_justify(Gtk.Justification.LEFT)
+        label.set_markup('<span size="large">%s</span>' % lang_name)
+
+        alignment = Gtk.Alignment.new(0, 0, 0, 0)
+        alignment.add(label)
+        label.show()
+
+        evbox = Gtk.EventBox()
+        self._language_evboxes[lang_code] = evbox
+        evbox.connect(
+            'button-press-event',
+            self._language_changed_event_cb,
+            lang_code)
+
+        if lang_code == current_lang:
+            evbox.modify_bg(0, style.COLOR_BUTTON_GREY.get_gdk_color())
+        else:
+            evbox.modify_bg(0, style.COLOR_BLACK.get_gdk_color())
+
+        evbox.add(alignment)
+        alignment.show()
+        self._language_box.pack_start(evbox, False, False, 0)
+        evbox.show()
+
+    self._language_palette = self._language_button.get_palette()
+    self._language_palette.set_content(self._language_box)
+    self._language_box.show_all()
 
     def _make_kokoro(self):
         self._kokoro_voice_evboxes = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy
 torch
 transformers
 requests
+pyspellchecker

--- a/speech.py
+++ b/speech.py
@@ -38,6 +38,16 @@ LANGUAGE_CODES = {
     'ar': 'ar',
 }
 
+LANGUAGE_NAMES = {
+    'en': 'English',
+    'hi': 'Hindi',
+    'fr': 'French',
+    'it': 'Italian',
+    'pt': 'Portuguese',
+    'zh': 'Chinese (Mandarin)',
+    'ar': 'Arabic',
+}
+
 # Kokoro TTS imports
 try:
     from kokoro import KPipeline
@@ -65,6 +75,7 @@ class Speech(GstSpeechPlayer):
         
         # Initialize Kokoro pipeline if available
         self._pipeline_lock = threading.Lock()
+        self.current_language = 'en'
         if KOKORO_AVAILABLE:
             # threading.Thread(target=self.setup_kokoro).start()
             threading.Thread(target=self.setup_kokoro, args=('en',)).start()
@@ -91,7 +102,7 @@ class Speech(GstSpeechPlayer):
 
    
     
-    # MY YOUR CHANGE (supports multiple languages):
+    
     
 
     def setup_kokoro(self, language='en'):
@@ -141,6 +152,22 @@ class Speech(GstSpeechPlayer):
             logger.debug(f"Kokoro voice set to: {voice_name}")
         else:
             logger.warning(f"Invalid Kokoro voice: {voice_name}.")
+
+    def get_available_languages(self):
+        """Return list of supported language codes."""
+        return list(LANGUAGE_CODES.keys())
+    
+    def set_language(self, lang_code):
+        """Change the TTS language at runtime."""
+        if lang_code in LANGUAGE_CODES:
+            self.current_language = lang_code
+            threading.Thread(
+                target=self.setup_kokoro,
+                args=(lang_code,)
+            ).start()
+            logger.debug(f"Language changed to: {lang_code}")
+        else:
+            logger.warning(f"Unsupported language code: {lang_code}")
 
     def get_available_kokoro_voices(self):
         return self.kokoro_voices.copy()

--- a/speech.py
+++ b/speech.py
@@ -19,6 +19,9 @@
 import numpy
 import threading
 
+from collections import OrderedDict
+import hashlib
+
 from gi.repository import Gst
 from gi.repository import GLib
 from gi.repository import GObject
@@ -75,6 +78,9 @@ class Speech(GstSpeechPlayer):
         
         # Initialize Kokoro pipeline if available
         self._pipeline_lock = threading.Lock()
+        self._audio_cache = OrderedDict()
+        self._cache_lock = threading.Lock()
+        self._max_cache_size = 20
         self.current_language = 'en'
         if KOKORO_AVAILABLE:
             # threading.Thread(target=self.setup_kokoro).start()
@@ -156,6 +162,43 @@ class Speech(GstSpeechPlayer):
     def get_available_languages(self):
         """Return list of supported language codes."""
         return list(LANGUAGE_CODES.keys())
+    def _get_cache_key(self, text, voice):
+        """Generate a unique cache key for text + voice combination."""
+        raw = f"{text}:{voice}"
+        return hashlib.md5(raw.encode()).hexdigest()
+    
+    def get_cached_audio(self, text, voice):
+        """Return cached audio for text+voice if available, else None."""
+        key = self._get_cache_key(text, voice)
+        with self._cache_lock:
+            if key in self._audio_cache:
+                self._audio_cache.move_to_end(key)
+                logger.debug(f"Cache HIT for: {text[:30]}")
+                return self._audio_cache[key]
+        logger.debug(f"Cache MISS for: {text[:30]}")
+        return None
+    
+    def cache_audio(self, text, voice, audio_chunks):
+        """Store generated audio in cache with LRU eviction."""
+        key = self._get_cache_key(text, voice)
+        with self._cache_lock:
+            if key in self._audio_cache:
+                self._audio_cache.move_to_end(key)
+            else:
+                if len(self._audio_cache) >= self._max_cache_size:
+                    evicted = self._audio_cache.popitem(last=False)
+                    logger.debug(f"Cache evicted oldest entry")
+                self._audio_cache[key] = audio_chunks
+                logger.debug(f"Cached audio for: {text[:30]}")
+
+    def clear_cache(self):
+        """Clear all cached audio."""
+        with self._cache_lock:
+            self._audio_cache.clear()
+        logger.debug("Audio cache cleared")
+    
+
+    
     
     def set_language(self, lang_code):
         """Change the TTS language at runtime."""
@@ -426,6 +469,56 @@ class Speech(GstSpeechPlayer):
             
         except Exception as e:
             # Signalling EOS here as well, but I'm adding error to logs
+            logger.error(f"Error in Kokoro audio streaming: {e}")
+            if appsrc:
+                appsrc.emit("end-of-stream")
+    def _stream_kokoro_audio(self, text, voice):
+        """Stream Kokoro audio chunks to the GStreamer pipeline.
+        Uses cache for repeated phrases to avoid regenerating audio.
+        """
+        try:
+            appsrc = self.pipeline.get_by_name('kokoro_src')
+            if not appsrc:
+                logger.error("Could not find kokoro_src element")
+                return
+
+            caps = Gst.Caps.from_string(
+            "audio/x-raw,format=F32LE,layout=interleaved,rate=24000,channels=1"
+            )
+            appsrc.set_property("caps", caps)
+
+            # Check cache first
+            cached = self.get_cached_audio(text, voice)
+            if cached:
+                logger.debug("Serving audio from cache")
+                for data_bytes in cached:
+                    buf = Gst.Buffer.new_wrapped(data_bytes)
+                    ret = appsrc.emit("push-buffer", buf)
+                    if ret != Gst.FlowReturn.OK:
+                        logger.error("Error pushing cached buffer")
+                        break
+                appsrc.emit("end-of-stream")
+                return
+
+            # Not in cache — generate with Kokoro and cache it
+            audio_generator = self.kokoro_pipeline(text, voice=voice)
+            chunks_to_cache = []
+
+            for i, (gs, ps, audio_chunk) in enumerate(audio_generator):
+                data_bytes = audio_chunk.numpy().tobytes()
+                chunks_to_cache.append(data_bytes)
+
+                buf = Gst.Buffer.new_wrapped(data_bytes)
+                ret = appsrc.emit("push-buffer", buf)
+                if ret != Gst.FlowReturn.OK:
+                    logger.error(f"Error pushing buffer {i} to GStreamer")
+                    break
+
+            # Save to cache for next time
+            self.cache_audio(text, voice, chunks_to_cache)
+            appsrc.emit("end-of-stream")
+
+        except Exception as e:
             logger.error(f"Error in Kokoro audio streaming: {e}")
             if appsrc:
                 appsrc.emit("end-of-stream")

--- a/speech.py
+++ b/speech.py
@@ -22,6 +22,8 @@ import threading
 from collections import OrderedDict
 import hashlib
 
+from spellchecker import SpellChecker
+
 from gi.repository import Gst
 from gi.repository import GLib
 from gi.repository import GObject
@@ -196,7 +198,55 @@ class Speech(GstSpeechPlayer):
         with self._cache_lock:
             self._audio_cache.clear()
         logger.debug("Audio cache cleared")
-    
+
+    def correct_spelling(self, text, lang_code='en'):
+        """Correct invented spellings before TTS processing.
+        
+        Corrects phonetic spellings common in child users
+        without modifying the original input — only for TTS.
+        
+        Args:
+            text: Input text to correct
+            lang_code: ISO language code (en, fr, es, pt, it)
+        
+        Returns:
+            Corrected text for TTS pronunciation
+        """
+        # Languages supported by pyspellchecker
+        SUPPORTED_LANGS = {
+            'en': 'en',
+            'fr': 'fr',
+            'es': 'es',
+            'pt': 'pt',
+            'it': 'it',
+        }
+        
+        if lang_code not in SUPPORTED_LANGS:
+            logger.debug(f"Spell correction not available for {lang_code}, skipping")
+            return text
+        
+        try:
+            spell = SpellChecker(language=SUPPORTED_LANGS[lang_code])
+            words = text.split()
+            corrected_words = []
+            
+            for word in words:
+                correction = spell.correction(word)
+                if correction and correction != word:
+                    logger.debug(f"Spelling corrected: {word} -> {correction}")
+                    corrected_words.append(correction)
+                else:
+                    corrected_words.append(word)
+            
+            corrected = ' '.join(corrected_words)
+            if corrected != text:
+                logger.debug(f"Full correction: '{text}' -> '{corrected}'")
+            return corrected
+        
+        except Exception as e:
+            logger.warning(f"Spell correction failed: {e}")
+            return text
+        
 
     
     
@@ -526,10 +576,13 @@ class Speech(GstSpeechPlayer):
     def speak(self, status, text):
         self.make_pipeline()
         
+    
+
         if KOKORO_AVAILABLE and self.kokoro_pipeline:
-            logger.debug('Using Kokoro TTS: voice=%s text=%s' % (self.current_kokoro_voice, text))
+            corrected_text = self.correct_spelling(text, self.current_language)
+            logger.debug('Using Kokoro TTS: voice=%s text=%s' % (self.current_kokoro_voice, corrected_text))
             self.restart_sound_device()
-            self._stream_kokoro_audio(text, self.current_kokoro_voice)
+            self._stream_kokoro_audio(corrected_text, self.current_kokoro_voice)
             
         else:
             # Fallback to espeak

--- a/speech.py
+++ b/speech.py
@@ -29,12 +29,14 @@ logger = logging.getLogger('speak')
 from sugar3.speech import GstSpeechPlayer
 
 LANGUAGE_CODES = {
-    'english': 'a',
-    'hindi': 'h',
-    'french': 'f',
-    'italian': 'i',
-    'portuguese': 'p',
-    }
+    'en': 'a',
+    'hi': 'h',
+    'fr': 'f',
+    'it': 'i',
+    'pt': 'p',
+    'zh': 'z',
+    'ar': 'ar',
+}
 
 # Kokoro TTS imports
 try:
@@ -62,10 +64,11 @@ class Speech(GstSpeechPlayer):
         self.pipeline = None
         
         # Initialize Kokoro pipeline if available
-        self.kokoro_pipeline = None
+        self._pipeline_lock = threading.Lock()
         if KOKORO_AVAILABLE:
             # threading.Thread(target=self.setup_kokoro).start()
-            threading.Thread(target=lambda: self.setup_kokoro('english')).start()
+            threading.Thread(target=self.setup_kokoro, args=('en',)).start()
+
 
         
         # Predefined Kokoro voices for future GUI selection - TODO
@@ -91,11 +94,12 @@ class Speech(GstSpeechPlayer):
     # MY YOUR CHANGE (supports multiple languages):
     
 
-    def setup_kokoro(self, language='english'):
+    def setup_kokoro(self, language='en'):
         """Initialize Kokoro TTS pipeline for the specified language.
     
         Args:
-            language: Language name (english, hindi, french, italian, portuguese)
+            language: Language ISO code (en, hi, fr, it, pt, zh, ar)
+
         """
         lang_code = LANGUAGE_CODES.get(language, 'a')
         self.kokoro_pipeline = KPipeline(lang_code=lang_code)
@@ -105,13 +109,14 @@ class Speech(GstSpeechPlayer):
         """Change the TTS language at runtime.
     
         Args:
-            language: Language name (english, hindi, french, italian, portuguese)
+            language: Language ISO code (en, hi, fr, it, pt, zh, ar)
+
         """
     
         if language not in LANGUAGE_CODES:
             logger.warning(f"Unsupported language: {language}. Defaulting to English.")
-            language = 'english'
-        threading.Thread(target=lambda: self.setup_kokoro(language)).start()
+            language = 'en'
+        threading.Thread(target=self.setup_kokoro, args=(language,)).start()
         logger.debug(f"Language changed to: {language}")
 
     def disconnect_all(self):

--- a/speech.py
+++ b/speech.py
@@ -116,19 +116,19 @@ class Speech(GstSpeechPlayer):
         self.kokoro_pipeline = KPipeline(lang_code=lang_code)
         logger.debug(f"Kokoro initialized for language: {language} (code: {lang_code})")
 
-    def set_language(self, language='english'):
-        """Change the TTS language at runtime.
+    # def set_language(self, language='english'):
+    #     """Change the TTS language at runtime.
     
-        Args:
-            language: Language ISO code (en, hi, fr, it, pt, zh, ar)
+    #     Args:
+    #         language: Language ISO code (en, hi, fr, it, pt, zh, ar)
 
-        """
+    #     """
     
-        if language not in LANGUAGE_CODES:
-            logger.warning(f"Unsupported language: {language}. Defaulting to English.")
-            language = 'en'
-        threading.Thread(target=self.setup_kokoro, args=(language,)).start()
-        logger.debug(f"Language changed to: {language}")
+    #     if language not in LANGUAGE_CODES:
+    #         logger.warning(f"Unsupported language: {language}. Defaulting to English.")
+    #         language = 'en'
+    #     threading.Thread(target=self.setup_kokoro, args=(language,)).start()
+    #     logger.debug(f"Language changed to: {language}")
 
     def disconnect_all(self):
         for cb in ['peak', 'wave', 'idle']:

--- a/speech.py
+++ b/speech.py
@@ -28,6 +28,14 @@ logger = logging.getLogger('speak')
 
 from sugar3.speech import GstSpeechPlayer
 
+LANGUAGE_CODES = {
+    'english': 'a',
+    'hindi': 'h',
+    'french': 'f',
+    'italian': 'i',
+    'portuguese': 'p',
+    }
+
 # Kokoro TTS imports
 try:
     from kokoro import KPipeline
@@ -56,7 +64,9 @@ class Speech(GstSpeechPlayer):
         # Initialize Kokoro pipeline if available
         self.kokoro_pipeline = None
         if KOKORO_AVAILABLE:
-            threading.Thread(target=self.setup_kokoro).start()
+            # threading.Thread(target=self.setup_kokoro).start()
+            threading.Thread(target=lambda: self.setup_kokoro('english')).start()
+
         
         # Predefined Kokoro voices for future GUI selection - TODO
         self.kokoro_voices = [
@@ -76,8 +86,33 @@ class Speech(GstSpeechPlayer):
         for cb in ['peak', 'wave', 'idle']:
             self._cb[cb] = None
 
-    def setup_kokoro(self):
-        self.kokoro_pipeline = KPipeline(lang_code='a')
+   
+    
+    # MY YOUR CHANGE (supports multiple languages):
+    
+
+    def setup_kokoro(self, language='english'):
+        """Initialize Kokoro TTS pipeline for the specified language.
+    
+        Args:
+            language: Language name (english, hindi, french, italian, portuguese)
+        """
+        lang_code = LANGUAGE_CODES.get(language, 'a')
+        self.kokoro_pipeline = KPipeline(lang_code=lang_code)
+        logger.debug(f"Kokoro initialized for language: {language} (code: {lang_code})")
+
+    def set_language(self, language='english'):
+        """Change the TTS language at runtime.
+    
+        Args:
+            language: Language name (english, hindi, french, italian, portuguese)
+        """
+    
+        if language not in LANGUAGE_CODES:
+            logger.warning(f"Unsupported language: {language}. Defaulting to English.")
+            language = 'english'
+        threading.Thread(target=lambda: self.setup_kokoro(language)).start()
+        logger.debug(f"Language changed to: {language}")
 
     def disconnect_all(self):
         for cb in ['peak', 'wave', 'idle']:


### PR DESCRIPTION
## Problem
Every time Speak-AI speaks a phrase, Kokoro regenerates 
audio from scratch. On low-powered devices like XO laptops 
this causes noticeable lag especially for repeated phrases.

## Solution
Implemented an in-memory LRU (Least Recently Used) cache 
for Kokoro TTS audio:
- Cache stores generated audio chunks per text+voice combo
- Cache key uses MD5 hash of text+voice for fast lookup
- LRU eviction keeps cache size within 20 entries
- Thread-safe using threading.Lock()

## Performance Impact
- Repeated phrases (IDLE_PHRASES etc.) served instantly
- Reduces CPU usage on resource-constrained devices
- Directly addresses GSoC 2026 project goal:
  "Implementing caching strategies for commonly used phrases"

## New Methods Added to Speech class
- get_cached_audio(text, voice)
- cache_audio(text, voice, chunks)
- clear_cache()
- _get_cache_key(text, voice)