### PR TITLE
Add placeholder text to input textbox

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -209,12 +209,13 @@ class SpeakActivity(activity.Activity):
         # make an audio device for playing back and rendering audio
         self.connect('notify::active', self._active_cb)
         self._cfg = {}
-
+        
         # make a box to type into
         self._entry_box = Gtk.HBox()
-
+        
         if self._tablet_mode:
             self._entry = Gtk.Entry()
+            self._entry.set_placeholder_text("Type something to speak...")
             self._entry_box.pack_start(self._entry, True, True, 0)
             talk_button = ToolButton('microphone')
             talk_button.set_tooltip(_('Speak'))
@@ -224,14 +225,16 @@ class SpeakActivity(activity.Activity):
             self._entrycombo = Gtk.ComboBoxText.new_with_entry()
             self._entrycombo.connect('changed', self._combo_changed_cb)
             self._entry = self._entrycombo.get_child()
+            self._entry.set_placeholder_text("Type something to speak...")
             self._entry.set_size_request(-1, style.GRID_CELL_SIZE)
             self._entry_box.pack_start(self._entrycombo, True, True, 0)
+        
         self._entry.set_editable(True)
         self._entry.connect('activate', self._entry_activate_cb)
         self._entry.connect('key-press-event', self._entry_key_press_cb)
         self._entry.modify_font(Pango.FontDescription('sans bold 24'))
         self._entry_box.show()
-
+        
         self.face = face.View(fill_color=lighter)
         self._cartoon_face = self.face
         self.face.set_size_request(


### PR DESCRIPTION
Adds a placeholder text ("Type something to speak...") to the input field to improve usability for new users.

Handled both tablet and non-tablet modes.