### PR TITLE
Remove duplicate entries from Kokoro voices list

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -59,19 +59,23 @@ class Speech(GstSpeechPlayer):
             threading.Thread(target=self.setup_kokoro).start()
         
         # Predefined Kokoro voices for future GUI selection - TODO
-        self.kokoro_voices = [
-            'af_heart', 'af_alloy', 'af_aoede', 'af_bella', 'af_jessica', 'af_kore', 'af_nicole',
-            'af_nova', 'af_river', 'af_sarah', 'af_sky','am_adam', 'am_echo', 'am_eric', 'am_fenrir',
-            'am_adam', 'am_echo', 'am_eric', 'am_fenrir', 'am_liam', 'am_michael', 'am_onyx',
-            'am_puck', 'am_santa', 'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily', 'bm_daniel',
-            'bm_fable', 'bm_george', 'bm_lewis', 'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro',
-            'jm_kumo', 'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi', 'zm_yunjian',
-            'zm_yunxi', 'zm_yunxia', 'zm_yunyang', 'ef_dora', 'em_alex', 'em_santa',
-            'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
-            'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
+        raw_voices = [
+        'af_heart', 'af_alloy', 'af_aoede', 'af_bella', 'af_jessica', 'af_kore', 'af_nicole',
+        'af_nova', 'af_river', 'af_sarah', 'af_sky','am_adam', 'am_echo', 'am_eric', 'am_fenrir',
+        'am_adam', 'am_echo', 'am_eric', 'am_fenrir', 'am_liam', 'am_michael', 'am_onyx',
+        'am_puck', 'am_santa', 'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily', 'bm_daniel',
+        'bm_fable', 'bm_george', 'bm_lewis', 'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro',
+        'jm_kumo', 'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi', 'zm_yunjian',
+        'zm_yunxi', 'zm_yunxia', 'zm_yunyang', 'ef_dora', 'em_alex', 'em_santa',
+        'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
+        'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
         ]
+    
+        seen = set()
+        self.kokoro_voices = [v for v in raw_voices if not (v in seen or seen.add(v))]
+        
         self.current_kokoro_voice = 'af_heart'
-
+        
         self._cb = {}
         for cb in ['peak', 'wave', 'idle']:
             self._cb[cb] = None


### PR DESCRIPTION
Removes duplicate entries from the Kokoro voices list while preserving order.

This ensures no duplicate voices appear in the UI and prevents future duplication issues.