### PR TITLE
chore: update .gitignore to prevent API key leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,20 @@ dist
 .0sugar
 *~
 *.pyc
+__pycache__/
+*.pyo
+*.egg-info/
+
+# API keys — never commit secrets
+API_KEY.txt
+.env
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Problem
`LLM.py` reads an API key from `API_KEY.txt`, but the current `.gitignore` doesn't exclude this file. A contributor could accidentally commit their API key to the public repository.

## Changes
- Added `API_KEY.txt` and `.env` to prevent accidental secret commits
- Added `__pycache__/`, `*.pyo`, `*.egg-info/` (Python build artifacts)
- Added common IDE files (`.vscode/`, `.idea/`, swap files)
- Added OS files (`.DS_Store`, `Thumbs.db`)
- Preserved all existing entries