### PR TITLE
fix: improve error handling and add type hints in LLM.py

### DIFF
--- a/LLM.py
+++ b/LLM.py
@@ -2,9 +2,12 @@ import requests
 import json
 import socket
 import logging
+from typing import Optional
 
-#TODO: Dont hard code these, need to see how sugar as a whole manages API Keys
+# TODO: Don't hard code these, need to see how Sugar as a whole
+# manages API Keys
 API_URL = "https://ai.sugarlabs.org/ask-llm-prompted"
+
 try:
     with open("API_KEY.txt", "r") as f:
         API_KEY = f.read().strip()
@@ -12,41 +15,69 @@ except OSError:
     logging.error("Missing API_KEY.txt file.")
     API_KEY = None
 
-DEFAULT_PROMPT = "You are a friendly teacher named Jane who is 28 years old. You teach 10 year old children. Always give helpful, educational responses in simple words that children can understand. Keep your answers between 20-40 words. Be encouraging and enthusiastic but never use emojis(ever). If you notice spelling mistakes, gently correct them. Stay focused on the topic and give relevant answers."
+DEFAULT_PROMPT = (
+    "You are a friendly teacher named Jane who is 28 years old. "
+    "You teach 10 year old children. Always give helpful, educational "
+    "responses in simple words that children can understand. Keep your "
+    "answers between 20-40 words. Be encouraging and enthusiastic but "
+    "never use emojis(ever). If you notice spelling mistakes, gently "
+    "correct them. Stay focused on the topic and give relevant answers."
+)
 
-def is_connected():
+
+def is_connected() -> bool:
+    """Check if the device has an active internet connection."""
     try:
         socket.create_connection(("8.8.8.8", 53), timeout=5)
         logging.debug("Connection to 8.8.8.8 successful")
         return True
     except OSError:
-        logging.error("Error: No internet connection. Please check your network.")
+        logging.error(
+            "Error: No internet connection. Please check your network."
+        )
         return False
 
-def ask_llm_prompted(question, custom_prompt = DEFAULT_PROMPT, timeout=120, max_length=200):
+
+def ask_llm_prompted(
+    question: str,
+    custom_prompt: str = DEFAULT_PROMPT,
+    timeout: int = 120,
+    max_length: int = 200
+) -> Optional[str]:
+    """Send a question to the Sugar Labs LLM API and return the response.
+
+    Args:
+        question: The user's question to send to the LLM.
+        custom_prompt: System prompt for the LLM persona.
+        timeout: Maximum seconds to wait for a response.
+        max_length: Maximum length of the generated response.
+
+    Returns:
+        The LLM's answer as a string, or None if the request failed.
+    """
     if API_KEY is None:
         logging.error("Missing API key file: API_KEY.txt")
-        return False
-    
+        return None
+
     if not is_connected():
-        return False
+        return None
 
     headers = {
         "X-API-Key": API_KEY,
         "Content-Type": "application/json"
     }
-    
+
     payload = {
         "question": question,
         "custom_prompt": custom_prompt,
         "max_length": max_length,
         "truncation": True,
-        "repetition_penalty": 1.2,  # Slightly higher to avoid repetition
-        "temperature": 0.3,         # Lower for more consistent responses
-        "top_p": 0.8,              # Slightly lower for better focus
-        "top_k": 20                # Much lower for more predictable responses
+        "repetition_penalty": 1.2,
+        "temperature": 0.3,
+        "top_p": 0.8,
+        "top_k": 20
     }
-    
+
     try:
         response = requests.post(
             API_URL,
@@ -56,36 +87,39 @@ def ask_llm_prompted(question, custom_prompt = DEFAULT_PROMPT, timeout=120, max_
         )
 
         if 500 <= response.status_code < 600:
-            logging.error(f"Server error: {response.status_code}")
-            return False
+            logging.error("Server error: %d", response.status_code)
+            return None
         response.raise_for_status()
 
-        # Parse the JSON response.
         data = response.json()
 
-        # Check if the 'answer' key is in the response and return it.
         if isinstance(data, dict) and "answer" in data:
             return data['answer']
 
-        else:
-            return data
+        logging.warning("Unexpected response format: %s", type(data))
+        return None
 
     except requests.exceptions.Timeout:
-        logging.error(f"The request timed out after {timeout} seconds. The server might be slow.")
+        logging.error(
+            "The request timed out after %d seconds. "
+            "The server might be slow.", timeout
+        )
     except requests.exceptions.RequestException as e:
-        logging.error(f"An error occurred: {e}")
+        logging.error("An error occurred: %s", e)
         try:
-            logging.error(f"Response content: {response.text}")
+            logging.error("Response content: %s", response.text)
         except Exception:
             pass
-    return False
+    return None
+
 
 if __name__ == "__main__":
-    
     while True:
-        answer = ask_llm_prompted(question=input("Enter question to LLM"),custom_prompt=DEFAULT_PROMPT)
+        answer = ask_llm_prompted(
+            question=input("Enter question to LLM: "),
+            custom_prompt=DEFAULT_PROMPT
+        )
         if answer:
             print(f'LLM ANS: {answer}')
-        
         else:
             print("Error, LLM did not respond")


### PR DESCRIPTION
## Problem
- `ask_llm_prompted()` returns `False` on errors but `str` on success, mixing return types. In `activity.py` (line 1295), the check `if llm_response == None` doesn't catch `False`.
- No type hints or docstrings.
- f-strings in logging are evaluated eagerly even when log level is disabled.

## Changes
- Return `None` instead of `False` on all error paths → consistent `Optional[str]`
- Added type hints to all functions and parameters (PEP 484)
- Added docstrings (Google style)
- Used `%s` lazy formatting in logging calls
- Broke long prompt string for PEP 8 compliance
- Removed bare `return data` fallback that could leak unparsed dicts

## Testing
Tested with and without `API_KEY.txt` — errors correctly return `None`.