### PR TITLE
Fix TypeError crash in robot mode voice switching

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -1482,7 +1482,6 @@ class SpeakActivity(activity.Activity):
                                 'old_voice': self._current_voice[0].friendlyname,
                                 'new_voice': new_voice.friendlyname}
             else:
-                new_voice = new_voice[0]
                 sorry = None
 
             self._set_voice(new_voice)


### PR DESCRIPTION
This PR fixes a crash in robot mode voice switching caused by invalid indexing of a Voice object.

**Steps to reproduce:**

* Launch Speak
* Select a voice whose short name matches a robot voice (typically English or Spanish bot voice)
* Toggle to Robot mode

**Observed:**

* Crash with: `TypeError: 'Voice' object is not subscriptable`

**Root cause:**
In `__toggled_mode_robot_cb` (activity.py), when the current voice already matches a robot voice, `new_voice` is assigned as a `Voice` object. However, the else branch incorrectly treats it like a list and accesses `new_voice[0]`, leading to a runtime error.

**Fix:**
Removed the invalid indexing and used `new_voice` directly as a `Voice` object.

**Testing:**

* Reproduced the crash locally before the fix
* Verified clean robot mode switching after applying the change

This improves stability when switching between voice modes.
