### PR TITLE
Fix crash when setting photo face by adding error handling

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -1077,7 +1077,8 @@ class SpeakActivity(activity.Activity):
             if jobject and jobject.file_path:
                 selector = FaceSelector(jobject.file_path)
                 selector.connect('face-processed',
-                                 self._photo_face_processed_cb)
+                                 self.
+_photo_face_processed_cb)
                 selector.connect('cancel', self._photo_face_cancel_cb)
                 self._notebook.append_page(selector, Gtk.Label(''))
                 selector.show()
@@ -1090,18 +1091,25 @@ class SpeakActivity(activity.Activity):
         try:
             if not face_data:
                 logger.error("No face data received")
-                self.face.say_notification(_("Failed to load image"))
+                if self.face:
+                    self.face.say_notification(_("Failed to load image"))
                 return
-    
             lighter = style.Color(self._colors[_lighter_color(self._colors)])
-    
             view = photoface.View(*face_data, fill_color=lighter)
-    
             self._set_face(view, FACE_PHOTO)
-    
-        except Exception as e:
-            logger.error(f"Failed to set photo face: {e}")
-            self.face.say_notification(_("Failed to load image"))
+
+        except TypeError as error:
+            logger.error(f"Type error while setting photo face: {error}")
+            if self.face:
+                self.face.say_notification(_("Failed to load image"))
+        except ValueError as error:
+            logger.error(f"Value error while setting photo face: {error}")
+            if self.face:
+                self.face.say_notification(_("Failed to load image"))
+        except Exception as error:
+            logger.exception(f"Unexpected error while setting photo face: {error}")
+            if self.face:
+                self.face.say_notification(_("Failed to load image"))
 
     def _photo_face_cancel_cb(self, widget):
         self._notebook.set_current_page(0)

--- a/activity.py
+++ b/activity.py
@@ -1087,9 +1087,21 @@ class SpeakActivity(activity.Activity):
         chooser.destroy()
 
     def _photo_face_processed_cb(self, widget, *face_data):
-        lighter = style.Color(self._colors[_lighter_color(self._colors)])
-        self._set_face(photoface.View(*face_data, fill_color=lighter),
-                       FACE_PHOTO)
+        try:
+            if not face_data:
+                logger.error("No face data received")
+                self.face.say_notification(_("Failed to load image"))
+                return
+    
+            lighter = style.Color(self._colors[_lighter_color(self._colors)])
+    
+            view = photoface.View(*face_data, fill_color=lighter)
+    
+            self._set_face(view, FACE_PHOTO)
+    
+        except Exception as e:
+            logger.error(f"Failed to set photo face: {e}")
+            self.face.say_notification(_("Failed to load image"))
 
     def _photo_face_cancel_cb(self, widget):
         self._notebook.set_current_page(0)


### PR DESCRIPTION
## Steps to Reproduce the Crash

While testing the photo face feature, I found that the activity could crash if the face image could not be loaded properly. This can happen in cases where the image file is missing, corrupted, or not loaded correctly.

Steps to reproduce:

1. Open the Speak activity.
2. Choose the option to set the face from a photo.
3. Select an image from the Journal.
4. Remove or corrupt the selected image file from the activity data folder.
5. Restart the activity.
6. The activity attempts to load the saved face image.
7. Before this fix, the activity would crash due to an unhandled exception.
8. After this fix, the error is handled gracefully and the user is notified instead of the activity crashing.

## Summary of Fix

This PR improves error handling when setting the photo face:

* Added a check to handle cases where no face data is received.
* Added a safety check to ensure `self.face` is not `None` before calling `say_notification()`.
* Replaced broad exception handling with more specific exceptions (`TypeError`, `ValueError`).
* Added logging for unexpected errors to make debugging easier in the future.

Thank you for the review and suggestions — they helped improve the error handling and make the fix more robust.
