### PR TITLE
fix: prevent crash when kokoro_pipeline is not initialized

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -326,6 +326,11 @@ class Speech(GstSpeechPlayer):
 
     def _stream_kokoro_audio(self, text, voice):
         """Stream Kokoro audio chunks to the GStreamer pipeline"""
+
+        if not self.kokoro_pipeline:
+            logger.error("Kokoro pipeline not initialized")
+            return
+        
         try:
             # Getting the appsrc element
             appsrc = self.pipeline.get_by_name('kokoro_src')


### PR DESCRIPTION
While working with the Kokoro TTS path, I noticed that _stream_kokoro_audio uses self.kokoro_pipeline without checking if it has been initialized.

If initialization hasn’t completed yet (or fails), calling it directly can lead to a runtime error.

This change adds a simple guard at the beginning of the function to ensure the pipeline is available before using it. If it’s not initialized, the function logs an error and exits safely instead of crashing.

This makes the Kokoro audio path more robust, especially in cases where initialization is delayed or fails.