### PR TITLE
Remove duplicate entries from Kokoro voices list

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -71,6 +71,7 @@ class Speech(GstSpeechPlayer):
             'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
             'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
         ]))
+        
         self.current_kokoro_voice = 'af_heart'
 
         self._cb = {}

--- a/speech.py
+++ b/speech.py
@@ -103,7 +103,7 @@ class Speech(GstSpeechPlayer):
             logger.debug(f"Kokoro voice set to: {voice_name}")
         else:
             logger.warning(f"Invalid Kokoro voice: {voice_name}.")
-        
+            
     def get_available_kokoro_voices(self):
         return self.kokoro_voices.copy()
 

--- a/speech.py
+++ b/speech.py
@@ -98,7 +98,6 @@ class Speech(GstSpeechPlayer):
         self._cb['idle'] = self.connect('idle', cb)
 
     def set_kokoro_voice(self, voice_name):
-        """Set Kokoro voice. Falls back to default if invalid."""
         if voice_name in self.kokoro_voices:
             self.current_kokoro_voice = voice_name
             logger.debug(f"Kokoro voice set to: {voice_name}")

--- a/speech.py
+++ b/speech.py
@@ -71,7 +71,7 @@ class Speech(GstSpeechPlayer):
             'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
             'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
         ]))
-        
+
         self.current_kokoro_voice = 'af_heart'
 
         self._cb = {}
@@ -103,11 +103,7 @@ class Speech(GstSpeechPlayer):
             self.current_kokoro_voice = voice_name
             logger.debug(f"Kokoro voice set to: {voice_name}")
         else:
-            default_voice = self.get_default_kokoro_voices()[0]
-        logger.warning(
-            f"Invalid Kokoro voice: {voice_name}. Falling back to default: {default_voice}"
-        )
-        self.current_kokoro_voice = default_voice
+            logger.warning(f"Invalid Kokoro voice: {voice_name}.")
         
     def get_available_kokoro_voices(self):
         return self.kokoro_voices.copy()

--- a/speech.py
+++ b/speech.py
@@ -59,17 +59,18 @@ class Speech(GstSpeechPlayer):
             threading.Thread(target=self.setup_kokoro).start()
         
         # Predefined Kokoro voices for future GUI selection - TODO
-        self.kokoro_voices = [
+        self.kokoro_voices = list(dict.fromkeys([
             'af_heart', 'af_alloy', 'af_aoede', 'af_bella', 'af_jessica', 'af_kore', 'af_nicole',
-            'af_nova', 'af_river', 'af_sarah', 'af_sky','am_adam', 'am_echo', 'am_eric', 'am_fenrir',
-            'am_adam', 'am_echo', 'am_eric', 'am_fenrir', 'am_liam', 'am_michael', 'am_onyx',
-            'am_puck', 'am_santa', 'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily', 'bm_daniel',
-            'bm_fable', 'bm_george', 'bm_lewis', 'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro',
-            'jm_kumo', 'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi', 'zm_yunjian',
-            'zm_yunxi', 'zm_yunxia', 'zm_yunyang', 'ef_dora', 'em_alex', 'em_santa',
+            'af_nova', 'af_river', 'af_sarah', 'af_sky', 'am_adam', 'am_echo', 'am_eric', 'am_fenrir',
+            'am_liam', 'am_michael', 'am_onyx', 'am_puck', 'am_santa', 'bf_alice', 'bf_emma',
+            'bf_isabella', 'bf_lily', 'bm_daniel', 'bm_fable', 'bm_george', 'bm_lewis',
+            'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro', 'jm_kumo',
+            'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi',
+            'zm_yunjian', 'zm_yunxi', 'zm_yunxia', 'zm_yunyang',
+            'ef_dora', 'em_alex', 'em_santa',
             'ff_siwis', 'hf_alpha', 'hf_beta', 'hm_omega', 'hm_psi',
             'if_sara', 'im_nicola', 'pf_dora', 'pm_alex', 'pm_santa'
-        ]
+        ]))
         self.current_kokoro_voice = 'af_heart'
 
         self._cb = {}
@@ -96,12 +97,17 @@ class Speech(GstSpeechPlayer):
         self._cb['idle'] = self.connect('idle', cb)
 
     def set_kokoro_voice(self, voice_name):
+        """Set Kokoro voice. Falls back to default if invalid."""
         if voice_name in self.kokoro_voices:
             self.current_kokoro_voice = voice_name
             logger.debug(f"Kokoro voice set to: {voice_name}")
         else:
-            logger.warning(f"Invalid Kokoro voice: {voice_name}.")
-
+            default_voice = self.get_default_kokoro_voices()[0]
+        logger.warning(
+            f"Invalid Kokoro voice: {voice_name}. Falling back to default: {default_voice}"
+        )
+        self.current_kokoro_voice = default_voice
+        
     def get_available_kokoro_voices(self):
         return self.kokoro_voices.copy()
 


### PR DESCRIPTION
This PR removes duplicate entries from the predefined Kokoro voices list.

This is a small cleanup change, so I proceeded directly with a PR.

Previously, some voice identifiers were repeated, which could lead to unnecessary redundancy in voice selection.

This change ensures:
- All voice entries are unique
- Original order is preserved using dict.fromkeys
- Cleaner and more maintainable code

If needed, I can also create a corresponding issue for tracking.

Thanks!