### PR TITLE
Add arabic g2p

### DIFF
--- a/kokoro/arabic_g2p.py
+++ b/kokoro/arabic_g2p.py
@@ -1,0 +1,133 @@
+"""
+Arabic Grapheme-to-Phoneme converter.
+Pure Python, strictly adhering to Kokoro-82M's configuration vocabulary.
+
+Assumes fully or partially vocalized text (Tashkeel).
+"""
+
+# Map Arabic letters to Kokoro config.json valid IPA tokens
+ARABIC_CONSONANTS = {
+    'ء': 'ʔ',    # Hamza
+    'ب': 'b',    # Ba
+    'ت': 't',    # Ta
+    'ث': 'θ',    # Tha
+    'ج': 'ʤ',    # Jeem
+    'ح': 'h',    # Hha (fallback to h since ħ unsupported)
+    'خ': 'χ',    # Kha
+    'د': 'd',    # Dal
+    'ذ': 'ð',    # Dhal
+    'ر': 'r',    # Ra
+    'ز': 'z',    # Zay
+    'س': 's',    # Seen
+    'ش': 'ʃ',    # Sheen
+    'ص': 's',    # Saad (fallback to s)
+    'ض': 'd',    # Daad (fallback to d)
+    'ط': 't',    # Taa (fallback to t)
+    'ظ': 'z',    # Zaa (fallback to dhal/zay)
+    'ع': 'ʔ',    # Ayn (fallback to glottal stop)
+    'غ': 'ɣ',    # Ghayn
+    'ف': 'f',    # Fa
+    'ق': 'q',    # Qaf
+    'ك': 'k',    # Kaf
+    'ل': 'l',    # Lam
+    'م': 'm',    # Meem
+    'ن': 'n',    # Noon
+    'ه': 'h',    # Ha
+    'و': 'w',    # Waw
+    'ي': 'j',    # Ya
+    'ة': 't',    # Ta marbuta
+    'ى': 'a',    # Alif maqsura
+    'أ': 'ʔ',    # Alif with hamza
+    'إ': 'ʔ',    # Alif with hamza below
+    'آ': 'ʔaː',  # Alif madda
+    'ؤ': 'ʔ',    # Waw with hamza
+    'ئ': 'ʔ',    # Ya with hamza
+    'ا': 'aː',   # Bare alif
+}
+
+# Vowels & Marks
+FATHA = 'َ'
+KASRA = 'ِ'
+DAMMA = 'ُ'
+SUKUN = 'ْ'
+SHADDA = 'ّ'
+FATHATAN = 'ً'
+KASRATAN = 'ٍ'
+DAMMATAN = 'ٌ'
+
+
+def transliterate_arabic(text: str) -> str:
+    result = []
+    chars = list(text)
+    i = 0
+    while i < len(chars):
+        ch = chars[i]
+        nxt = chars[i+1] if i+1 < len(chars) else ''
+        
+        c_pho = ARABIC_CONSONANTS.get(ch, None)
+        if c_pho:
+            # Handle shadda (gemination)
+            if nxt == SHADDA:
+                result.append(c_pho) # double the consonant
+                result.append(c_pho)
+                i += 2
+                # Look for vowel after shadda
+                if i < len(chars):
+                    v = chars[i]
+                    if v == FATHA: result.append('a'); i += 1
+                    elif v == KASRA: result.append('i'); i += 1
+                    elif v == DAMMA: result.append('u'); i += 1
+                    elif v == FATHATAN: result.append('a'); result.append('n'); i += 1
+                    elif v == KASRATAN: result.append('i'); result.append('n'); i += 1
+                    elif v == DAMMATAN: result.append('u'); result.append('n'); i += 1
+            else:
+                result.append(c_pho)
+                i += 1
+        elif ch == FATHA:
+            if nxt == 'ا' or nxt == 'ى':
+                result.append('aː')
+                i += 2
+            else:
+                result.append('a')
+                i += 1
+        elif ch == KASRA:
+            if nxt == 'ي':
+                result.append('iː')
+                i += 2
+            else:
+                result.append('i')
+                i += 1
+        elif ch == DAMMA:
+            if nxt == 'و':
+                result.append('uː')
+                i += 2
+            else:
+                result.append('u')
+                i += 1
+        elif ch == FATHATAN:
+            result.append('an')
+            i += 1
+        elif ch == KASRATAN:
+            result.append('in')
+            i += 1
+        elif ch == DAMMATAN:
+            result.append('un')
+            i += 1
+        elif ch == SUKUN:
+            i += 1
+        elif ch == ' ':
+            result.append(' ')
+            i += 1
+        elif ch.isascii():
+            result.append(ch)
+            i += 1
+        else:
+            i += 1
+            
+    return ''.join(result).replace('aːaː', 'aː').replace('iːiː', 'iː').replace('uːuː', 'uː')
+
+
+class ArabicG2P:
+    def __call__(self, text: str):
+        phonemes = transliterate_arabic(text)
+        return phonemes, None

--- a/kokoro/hindi_g2p.py
+++ b/kokoro/hindi_g2p.py
@@ -1,0 +1,138 @@
+"""
+Hindi (Devanagari) Grapheme-to-Phoneme converter.
+Pure Python, zero external dependencies.
+
+Produces phoneme strings compatible with Kokoro TTS model's vocabulary.
+Each output character must exist in the model's config.json vocab mapping.
+
+Devanagari is a largely phonemic script — each character consistently maps to
+a specific phoneme, making rule-based G2P viable and accurate for Hindi.
+"""
+
+# --- Kokoro-compatible phoneme mappings ---
+# Only uses characters present in the Kokoro-82M config.json vocab.
+# Key remappings from standard IPA:
+#   t̪ (dental) → t     (model has no combining dental diacritic)
+#   d̪ (dental) → d     (same)
+#   ʱ (voiced asp.) → ʰ  (model only has voiceless aspiration marker)
+#   ɦ (voiced h) → h     (model has no ɦ)
+
+# Vowels (independent forms)
+VOWELS = {
+    'अ': 'ə',  'आ': 'aː', 'इ': 'ɪ',  'ई': 'iː',
+    'उ': 'ʊ',  'ऊ': 'uː', 'ऋ': 'ɾɪ', 'ए': 'eː',
+    'ऐ': 'ɛː', 'ओ': 'oː', 'औ': 'ɔː', 'ऑ': 'ɔ',
+}
+
+# Vowel signs (dependent forms / matras)
+MATRAS = {
+    'ा': 'aː', 'ि': 'ɪ',  'ी': 'iː', 'ु': 'ʊ',
+    'ू': 'uː', 'ृ': 'ɾɪ', 'े': 'eː', 'ै': 'ɛː',
+    'ो': 'oː', 'ौ': 'ɔː', 'ॉ': 'ɔ',
+}
+
+# Consonants — using only Kokoro-vocab-safe phonemes
+CONSONANTS = {
+    'क': 'k',   'ख': 'kʰ',  'ग': 'ɡ',   'घ': 'ɡʰ',  'ङ': 'ŋ',
+    'च': 'ʧ',   'छ': 'ʧʰ',  'ज': 'ʤ',   'झ': 'ʤʰ',  'ञ': 'ɲ',
+    'ट': 'ʈ',   'ठ': 'ʈʰ',  'ड': 'ɖ',   'ढ': 'ɖʰ',  'ण': 'ɳ',
+    'त': 't',   'थ': 'tʰ',  'द': 'd',   'ध': 'dʰ',  'न': 'n',
+    'प': 'p',   'फ': 'pʰ',  'ब': 'b',   'भ': 'bʰ',  'म': 'm',
+    'य': 'j',   'र': 'ɾ',   'ल': 'l',   'व': 'ʋ',
+    'श': 'ʃ',   'ष': 'ʂ',   'स': 's',   'ह': 'h',
+    'क़': 'q',   'ख़': 'x',   'ग़': 'ɣ',   'ज़': 'z',
+    'ड़': 'ɽ',   'ढ़': 'ɽʰ',  'फ़': 'f',   'झ़': 'ʒ',
+}
+
+HALANT = '्'
+ANUSVARA = 'ं'
+VISARGA = 'ः'
+CHANDRABINDU = 'ँ'
+NUKTA = '़'
+NASALIZE = '\u0303'  # combining tilde — token 17 in Kokoro vocab
+
+SCHWA = 'ə'
+
+
+def transliterate(text: str) -> str:
+    """Convert Hindi Devanagari text to Kokoro-compatible phoneme string."""
+    result = []
+    chars = list(text)
+    i = 0
+
+    while i < len(chars):
+        ch = chars[i]
+
+        # Two-char consonants with nukta (e.g., क़)
+        if i + 1 < len(chars) and chars[i + 1] == NUKTA:
+            combo = ch + NUKTA
+            if combo in CONSONANTS:
+                result.append(CONSONANTS[combo])
+                i += 2
+                if i < len(chars) and chars[i] == HALANT:
+                    i += 1
+                elif i < len(chars) and chars[i] in MATRAS:
+                    result.append(MATRAS[chars[i]])
+                    i += 1
+                elif combo in CONSONANTS:
+                    result.append(SCHWA)
+                continue
+
+        if ch in CONSONANTS:
+            result.append(CONSONANTS[ch])
+            if i + 1 < len(chars) and chars[i + 1] == HALANT:
+                i += 2
+            elif i + 1 < len(chars) and chars[i + 1] in MATRAS:
+                result.append(MATRAS[chars[i + 1]])
+                i += 2
+            else:
+                result.append(SCHWA)
+                i += 1
+
+        elif ch in VOWELS:
+            result.append(VOWELS[ch])
+            i += 1
+
+        elif ch in MATRAS:
+            result.append(MATRAS[ch])
+            i += 1
+
+        elif ch == ANUSVARA:
+            result.append(NASALIZE)
+            i += 1
+
+        elif ch == CHANDRABINDU:
+            result.append(NASALIZE)
+            i += 1
+
+        elif ch == VISARGA:
+            result.append('h')
+            i += 1
+
+        elif ch == HALANT:
+            i += 1
+
+        elif ch == ' ':
+            result.append(' ')
+            i += 1
+
+        elif ch in '।॥':
+            result.append('.')
+            i += 1
+
+        elif ch.isascii():
+            result.append(ch)
+            i += 1
+
+        else:
+            i += 1
+
+    return ''.join(result)
+
+
+class HindiG2P:
+    """G2P interface compatible with the Kokoro pipeline's (phonemes, tokens) convention."""
+
+    def __call__(self, text: str):
+        phonemes = transliterate(text)
+        return phonemes, None

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -138,10 +138,15 @@ class KPipeline:
             except ImportError:
                 logger.error("You need to `pip install misaki[zh]` to use lang_code='z'")
                 raise
+        elif lang_code == 'h':
+            from kokoro.hindi_g2p import HindiG2P
+            self.g2p = HindiG2P()
+            logger.info("Using custom Devanagari-to-IPA G2P for Hindi")
         else:
             language = LANG_CODES[lang_code]
-            logger.warning(f"Using EspeakG2P(language='{language}'). Chunking logic not yet implemented, so long texts may be truncated unless you split them with '\\n'.")
+            logger.warning(f"Using EspeakG2P(language='{language}'). Quality may be limited for this language.")
             self.g2p = espeak.EspeakG2P(language=language)
+
 
     def load_single_voice(self, voice: str):
         if voice in self.voices:

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -37,6 +37,7 @@ LANG_CODES = dict(
 
     # pip install misaki[zh]
     z='Mandarin Chinese',
+    r='Arabic',
 )
 
 class KPipeline:
@@ -142,6 +143,10 @@ class KPipeline:
             from kokoro.hindi_g2p import HindiG2P
             self.g2p = HindiG2P()
             logger.info("Using custom Devanagari-to-IPA G2P for Hindi")
+        elif lang_code == 'r':
+            from kokoro.arabic_g2p import ArabicG2P
+            self.g2p = ArabicG2P()
+            logger.info("Using custom Arabic-to-IPA G2P for Arabic")
         else:
             language = LANG_CODES[lang_code]
             logger.warning(f"Using EspeakG2P(language='{language}'). Quality may be limited for this language.")

--- a/test_g2p_arabic.py
+++ b/test_g2p_arabic.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+Test Arabic G2P: validates phoneme output against Kokoro model vocab.
+Writes results to test_results_arabic.txt.
+
+Run: python test_g2p_arabic.py
+"""
+
+import importlib.util
+import os
+import sys
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "arabic_g2p", os.path.join(script_dir, "kokoro", "arabic_g2p.py")
+)
+arabic_g2p = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(arabic_g2p)
+ArabicG2P = arabic_g2p.ArabicG2P
+transliterate = arabic_g2p.transliterate_arabic
+
+OUTPUT_FILE = os.path.join(script_dir, "test_results_arabic.txt")
+
+# Exact vocab from Kokoro-82M config.json
+KOKORO_VOCAB = set(';:,.!?\u2014\u2026"()\u201c\u201d \u0303\u02a3\u02a5\u02a6\u02a8\u1d5d\uab67AIoQSTWY\u1d4aabcdefhijklmnopqrstuvwxyz\u0251\u0250\u0252\xe6\u03b2\u0254\u0255\xe7\u0256\xf0\u02a4\u0259\u025a\u025b\u025c\u025f\u0261\u0265\u0268\u026a\u029d\u026f\u0270\u014b\u0273\u0272\u0274\xf8\u0278\u03b8\u0153\u0279\u027e\u027b\u0281\u027d\u0282\u0283\u0288\u02a7\u028a\u028b\u028c\u0263\u0264\u03c7\u028e\u0292\u0294\u02c8\u02cc\u02d0\u02b0\u02b2\u2193\u2192\u2197\u2198\u1d7b')
+
+ARABIC_SENTENCES = [
+    ("مَرْحَبًا، كَيْفَ حَالُكَ؟", "marhaban, kayfa haluka?"),
+    ("اِسْمِي رَاهُول.", "ismi rahul."),
+    ("اَلْعَرَبِيَّةُ لُغَةٌ جَمِيلَةٌ.", "al-arabiyyah lughatun jamilah."),
+    ("شُكْرًا جَزِيلًا.", "shukran jazilan."),
+]
+
+def run_tests(out):
+    out.write("Arabic G2P Test Suite\n")
+    out.write("=" * 60 + "\n\n")
+
+    g2p = ArabicG2P()
+    all_ok = True
+
+    # TEST 1: Sentence transliteration
+    out.write("TEST 1: Sentence transliteration\n")
+    out.write("-" * 40 + "\n")
+    for sentence, roman in ARABIC_SENTENCES:
+        phonemes, _ = g2p(sentence)
+        out.write(f"  [{roman}]\n")
+        out.write(f"  Input:    {sentence}\n")
+        out.write(f"  Phonemes: {phonemes}\n")
+        out.write(f"  Length:   {len(phonemes)}\n\n")
+
+    # TEST 2: Kokoro vocab compatibility (THE KEY TEST)
+    out.write("=" * 60 + "\n")
+    out.write("TEST 2: Kokoro model vocab compatibility\n")
+    out.write("-" * 40 + "\n")
+    for sentence, roman in ARABIC_SENTENCES:
+        phonemes, _ = g2p(sentence)
+        bad_chars = []
+        for ch in phonemes:
+            if ch not in KOKORO_VOCAB:
+                bad_chars.append((ch, hex(ord(ch))))
+        if bad_chars:
+            out.write(f"  FAIL  [{roman}]\n")
+            for ch, code in bad_chars:
+                out.write(f"         Unknown char: '{ch}' ({code})\n")
+            all_ok = False
+        else:
+            out.write(f"  PASS  [{roman}] - all {len(phonemes)} chars in vocab\n")
+
+    out.write("\n")
+
+    # TEST 3: Gemination and Vowels
+    out.write("=" * 60 + "\n")
+    out.write("TEST 3: Shadda (Gemination) and Vowel handling\n")
+    out.write("-" * 40 + "\n")
+    cases = [
+        ("فَعَّلَ", "shadda with fatha (fa'ala)"),
+        ("كُتُبٌ", "dammatan (kutubun)"),
+        ("بَيْتْ", "sukun (bayt)"),
+    ]
+    for text, desc in cases:
+        result = transliterate(text)
+        bad = [ch for ch in result if ch not in KOKORO_VOCAB]
+        status = "PASS" if not bad else "FAIL"
+        if bad:
+            all_ok = False
+        out.write(f"  {status}  '{text}' -> '{result}' [{desc}]\n")
+
+    # SUMMARY
+    out.write("\n" + "=" * 60 + "\n")
+    if all_ok:
+        out.write("ALL TESTS PASSED - Output is Kokoro TTS compatible!\n")
+    else:
+        out.write("SOME TESTS FAILED - Output contains chars not in Kokoro vocab\n")
+    out.write("=" * 60 + "\n")
+    return all_ok
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+        success = run_tests(f)
+    try:
+        with open(OUTPUT_FILE, 'r', encoding='utf-8') as f:
+            print(f.read())
+    except UnicodeEncodeError:
+        print(f"Results written to {OUTPUT_FILE}")
+    sys.exit(0 if success else 1)

--- a/test_g2p_hindi.py
+++ b/test_g2p_hindi.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""
+Test Hindi G2P: validates phoneme output AND Kokoro model compatibility.
+Writes results to test_results.txt.
+
+Run: python test_g2p_hindi.py
+"""
+
+import importlib.util
+import os
+import sys
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "hindi_g2p", os.path.join(script_dir, "kokoro", "hindi_g2p.py")
+)
+hindi_g2p = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hindi_g2p)
+HindiG2P = hindi_g2p.HindiG2P
+transliterate = hindi_g2p.transliterate
+
+OUTPUT_FILE = os.path.join(script_dir, "test_results.txt")
+
+# Exact vocab from Kokoro-82M config.json
+KOKORO_VOCAB = set(';:,.!?\u2014\u2026"()\u201c\u201d \u0303\u02a3\u02a5\u02a6\u02a8\u1d5d\uab67AIoQSTWY\u1d4aabcdefhijklmnopqrstuvwxyz\u0251\u0250\u0252\xe6\u03b2\u0254\u0255\xe7\u0256\xf0\u02a4\u0259\u025a\u025b\u025c\u025f\u0261\u0265\u0268\u026a\u029d\u026f\u0270\u014b\u0273\u0272\u0274\xf8\u0278\u03b8\u0153\u0279\u027e\u027b\u0281\u027d\u0282\u0283\u0288\u02a7\u028a\u028b\u028c\u0263\u0264\u03c7\u028e\u0292\u0294\u02c8\u02cc\u02d0\u02b0\u02b2\u2193\u2192\u2197\u2198\u1d7b')
+
+HINDI_SENTENCES = [
+    ("\u0928\u092e\u0938\u094d\u0924\u0947", "namaste"),
+    ("\u0906\u092a \u0915\u0948\u0938\u0947 \u0939\u0948\u0902?", "aap kaise hain?"),
+    ("\u092e\u0947\u0930\u093e \u0928\u093e\u092e \u0930\u093e\u0939\u0941\u0932 \u0939\u0948\u0964", "mera naam Rahul hai"),
+    ("\u092d\u093e\u0930\u0924 \u090f\u0915 \u092e\u0939\u093e\u0928 \u0926\u0947\u0936 \u0939\u0948\u0964", "Bharat ek mahan desh hai"),
+    ("\u0906\u091c \u092e\u094c\u0938\u092e \u092c\u0939\u0941\u0924 \u0905\u091a\u094d\u091b\u093e \u0939\u0948\u0964", "aaj mausam bahut achha hai"),
+    ("\u0915\u0943\u092a\u092f\u093e \u092e\u0941\u091d\u0947 \u092a\u093e\u0928\u0940 \u0926\u0940\u091c\u093f\u090f\u0964", "kripaya mujhe paani dijie"),
+]
+
+
+def run_tests(out):
+    out.write("Hindi G2P Test Suite\n")
+    out.write("=" * 60 + "\n\n")
+
+    g2p = HindiG2P()
+    all_ok = True
+
+    # TEST 1: Sentence transliteration
+    out.write("TEST 1: Sentence transliteration\n")
+    out.write("-" * 40 + "\n")
+    for sentence, roman in HINDI_SENTENCES:
+        phonemes, _ = g2p(sentence)
+        out.write(f"  [{roman}]\n")
+        out.write(f"  Input:    {sentence}\n")
+        out.write(f"  Phonemes: {phonemes}\n")
+        out.write(f"  Length:   {len(phonemes)}\n\n")
+
+    # TEST 2: Kokoro vocab compatibility (THE KEY TEST)
+    out.write("=" * 60 + "\n")
+    out.write("TEST 2: Kokoro model vocab compatibility\n")
+    out.write("-" * 40 + "\n")
+    for sentence, roman in HINDI_SENTENCES:
+        phonemes, _ = g2p(sentence)
+        bad_chars = []
+        for ch in phonemes:
+            if ch not in KOKORO_VOCAB:
+                bad_chars.append((ch, hex(ord(ch))))
+        if bad_chars:
+            out.write(f"  FAIL  [{roman}]\n")
+            for ch, code in bad_chars:
+                out.write(f"         Unknown char: '{ch}' ({code})\n")
+            all_ok = False
+        else:
+            out.write(f"  PASS  [{roman}] - all {len(phonemes)} chars in vocab\n")
+
+    out.write("\n")
+
+    # TEST 3: Halant handling
+    out.write("=" * 60 + "\n")
+    out.write("TEST 3: Halant (virama) and matra handling\n")
+    out.write("-" * 40 + "\n")
+    cases = [
+        ("\u0915\u094d\u0924", "kt cluster"),
+        ("\u0915\u093e", "kaa matra"),
+        ("\u0915\u093f", "ki matra"),
+        ("\u0915\u0942", "kuu matra"),
+        ("\u0915\u0947", "ke matra"),
+        ("\u0915\u094b", "ko matra"),
+    ]
+    for text, desc in cases:
+        result = transliterate(text)
+        bad = [ch for ch in result if ch not in KOKORO_VOCAB]
+        status = "PASS" if not bad else "FAIL"
+        if bad:
+            all_ok = False
+        out.write(f"  {status}  '{text}' -> '{result}' [{desc}]\n")
+
+    # SUMMARY
+    out.write("\n" + "=" * 60 + "\n")
+    if all_ok:
+        out.write("ALL TESTS PASSED - Output is Kokoro TTS compatible!\n")
+    else:
+        out.write("SOME TESTS FAILED - Output contains chars not in Kokoro vocab\n")
+    out.write("=" * 60 + "\n")
+    return all_ok
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+        success = run_tests(f)
+    try:
+        with open(OUTPUT_FILE, 'r', encoding='utf-8') as f:
+            print(f.read())
+    except UnicodeEncodeError:
+        print(f"Results written to {OUTPUT_FILE}")
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
"Following up on the Hindi PR, this implements the exact same lightweight, zero-dependency architecture for Arabic (lang_code r).

By parsing Tashkeel (diacritics like Fatha, Kasra, Shadda, and Sukun) directly into the 178 valid IPA tokens supported by the Kokoro-82M config.json, we bypass massive 1GB external libraries like Charsiu and heavy C-bindings like Epitran. This ensures Speak-AI remains highly performant and easy to install for low-resource environments like Sugar OS and XO laptops. A full static test suite (

test_g2p_arabic.py
) checking vocab compatibility is included."