### PR TITLE
Add validation to prevent empty text input in speak()

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -365,7 +365,7 @@ class Speech(GstSpeechPlayer):
 
     def speak(self, status, text):
         if not text or not text.strip():
-            logger.warning("Empty or invalid text input. Skipping speech.")
+            logger.debug("Empty or invalid text input. Skipping speech.")
             return
 
         self.make_pipeline()

--- a/speech.py
+++ b/speech.py
@@ -364,6 +364,10 @@ class Speech(GstSpeechPlayer):
                 appsrc.emit("end-of-stream")
 
     def speak(self, status, text):
+        if not text or not text.strip():
+            logger.warning("Empty or invalid text input. Skipping speech.")
+            return
+
         self.make_pipeline()
         
         if KOKORO_AVAILABLE and self.kokoro_pipeline:


### PR DESCRIPTION
This PR adds validation to the speak() method to handle empty or invalid text input.

Currently, the method does not check whether the input text is empty, None, or whitespace, which may lead to unnecessary pipeline execution or unexpected behavior in TTS engines.

This change:
- Skips processing for empty or invalid input
- Logs a warning for better debugging
- Improves overall stability and efficiency

This is a safe and non-breaking improvement.

Thanks!