### PR TITLE
fix: use context managers for all open() calls in activity.py

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -162,8 +162,8 @@ def _has_accelerometer():
 
 def _is_tablet_mode():
     try:
-        fp = open('/dev/input/event4', 'rb')
-        fp.close()
+        with open('/dev/input/event4', 'rb'):
+            pass
     except IOError:
         return False
 
@@ -421,7 +421,8 @@ class SpeakActivity(activity.Activity):
         self._first_time = False
 
     def read_file(self, file_path):
-        self._cfg = json.loads(open(file_path, 'r').read())
+        with open(file_path, 'r') as f:
+            self._cfg = json.loads(f.read())
 
         current_voice = self.face.status.voice
 
@@ -501,7 +502,8 @@ class SpeakActivity(activity.Activity):
                'text': self._entry.props.text,
                'history': history,
                'persona': self._current_persona, }
-        open(file_path, 'w').write(json.dumps(cfg))
+        with open(file_path, 'w') as f:
+            f.write(json.dumps(cfg))
 
     def _look_at_cursor(self, entry, *ignored):
         # make the eyes track the motion of the text cursor
@@ -523,9 +525,8 @@ class SpeakActivity(activity.Activity):
 
     def _test_orientation(self):
         if _has_accelerometer():
-            fh = open(ACCELEROMETER_DEVICE)
-            string = fh.read()
-            fh.close()
+            with open(ACCELEROMETER_DEVICE) as fh:
+                string = fh.read()
             xyz = string[1:-2].split(',')
             x = int(xyz[0])
             y = int(xyz[1])


### PR DESCRIPTION
Replacing 4 bare open() calls with " with " statements at L165, L424, L504, L526. Prevents file descriptor leaks on XO hardware. Zero logic change.