### PR TITLE
fix: normalize LLM error return and fix None check bug

### DIFF
--- a/LLM.py
+++ b/LLM.py
@@ -26,10 +26,10 @@ def is_connected():
 def ask_llm_prompted(question, custom_prompt = DEFAULT_PROMPT, timeout=120, max_length=200):
     if API_KEY is None:
         logging.error("Missing API key file: API_KEY.txt")
-        return False
+        return None
     
     if not is_connected():
-        return False
+        return None
 
     headers = {
         "X-API-Key": API_KEY,
@@ -57,7 +57,7 @@ def ask_llm_prompted(question, custom_prompt = DEFAULT_PROMPT, timeout=120, max_
 
         if 500 <= response.status_code < 600:
             logging.error(f"Server error: {response.status_code}")
-            return False
+            return None
         response.raise_for_status()
 
         # Parse the JSON response.
@@ -78,7 +78,7 @@ def ask_llm_prompted(question, custom_prompt = DEFAULT_PROMPT, timeout=120, max_
             logging.error(f"Response content: {response.text}")
         except Exception:
             pass
-    return False
+    return None
 
 if __name__ == "__main__":
     

--- a/activity.py
+++ b/activity.py
@@ -1291,7 +1291,7 @@ class SpeakActivity(activity.Activity):
             
             llm_response = ask_llm_prompted(question=text, custom_prompt=custom_prompt)
 
-            if llm_response == None:
+            if not llm_response:
                 logging.error("LLM returned None response")
                 return None
 


### PR DESCRIPTION
## Problem
`ask_llm_prompted()` was returning `False` on all error paths (missing 
API key, no internet, server error, timeout). However the caller in 
`activity.py` was checking `if llm_response == None` — which `False` 
slips through since `False != None`.

This caused `is_profane(False)` to be called with a boolean instead of 
a string, resulting in a crash.

## Fix
- `LLM.py`: All error paths in `ask_llm_prompted()` now return `None` 
  instead of `False`. `None` is the correct Python convention for 
  "function returned no data".
- `activity.py`: Changed `if llm_response == None` to 
  `if not llm_response` which safely catches `None`, `False`, and empty 
  strings.

## Files Changed
- `LLM.py` — 4 return paths changed from `False` to `None`
- `activity.py` — L1295 check updated

## Notes
Zero logic change to the happy path. Only error handling is affected.
`is_connected()` return values are intentionally untouched as it is a 
boolean function.