### PR TITLE
Add language-aware Kokoro pipeline switching for multilingual TTS

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -47,6 +47,9 @@ VOICE_TO_LANG = {
     'jf': 'j', 'jm': 'j',
     'ef': 'e', 'em': 'e',
     'ff': 'f',
+    'zf': 'z', 'zm': 'z',
+    'if': 'i', 'im': 'i',
+    'pf': 'p', 'pm': 'p',
 }
 
 class Speech(GstSpeechPlayer):
@@ -59,17 +62,12 @@ class Speech(GstSpeechPlayer):
     def __init__(self):
         GstSpeechPlayer.__init__(self)
         self.pipeline = None
-        
-        # Initialize Kokoro pipeline if available
-        self.kokoro_pipeline = None
-        if KOKORO_AVAILABLE:
-            threading.Thread(target=self.setup_kokoro).start()
-        
+            
         # Predefined Kokoro voices for future GUI selection - TODO
         self.kokoro_voices = [
             'af_heart', 'af_alloy', 'af_aoede', 'af_bella', 'af_jessica', 'af_kore', 'af_nicole',
-            'af_nova', 'af_river', 'af_sarah', 'af_sky','am_adam', 'am_echo', 'am_eric', 'am_fenrir',
-            'am_adam', 'am_echo', 'am_eric', 'am_fenrir', 'am_liam', 'am_michael', 'am_onyx',
+            'af_nova', 'af_river', 'af_sarah', 'af_sky', 'am_adam', 'am_echo', 'am_eric', 'am_fenrir',
+            'am_liam', 'am_michael', 'am_onyx',
             'am_puck', 'am_santa', 'bf_alice', 'bf_emma', 'bf_isabella', 'bf_lily', 'bm_daniel',
             'bm_fable', 'bm_george', 'bm_lewis', 'jf_alpha', 'jf_gongitsune', 'jf_nezumi', 'jf_tebukuro',
             'jm_kumo', 'zf_xiaobei', 'zf_xiaoni', 'zf_xiaoxiao', 'zf_xiaoyi', 'zm_yunjian',
@@ -79,12 +77,23 @@ class Speech(GstSpeechPlayer):
         ]
         self.current_kokoro_voice = 'af_heart'
 
+         # Initialize Kokoro pipeline if available
+        self.kokoro_pipeline = None
+        if KOKORO_AVAILABLE:
+            threading.Thread(target=self.setup_kokoro).start()
+
         self._cb = {}
         for cb in ['peak', 'wave', 'idle']:
             self._cb[cb] = None
 
     def setup_kokoro(self):
-        self.kokoro_pipeline = KPipeline(lang_code='a')
+        if not hasattr(self, 'current_kokoro_voice'):
+            self.current_kokoro_voice = 'af_heart'
+        lang_code = VOICE_TO_LANG.get(
+            self.current_kokoro_voice[:2], 'a'
+        )
+        self.kokoro_pipeline = KPipeline(lang_code=lang_code)
+        self._current_lang_code = lang_code
 
     def disconnect_all(self):
         for cb in ['peak', 'wave', 'idle']:
@@ -107,11 +116,13 @@ class Speech(GstSpeechPlayer):
             self.current_kokoro_voice = voice_name
             prefix = voice_name[:2]
             lang_code = VOICE_TO_LANG.get(prefix, 'a')
-            if self.kokoro_pipeline:
+            current_lang = getattr(self, '_current_lang_code', None)
+            if self.kokoro_pipeline and lang_code != current_lang:
                 self.kokoro_pipeline = KPipeline(lang_code=lang_code)
+                self._current_lang_code = lang_code
             logger.debug(f"Kokoro voice set to: {voice_name}, lang: {lang_code}")
         else:
-            logger.warning(f"Invalid Kokoro voice: {voice_name}.")   
+            logger.warning(f"Invalid Kokoro voice: {voice_name}.")
 
     def get_available_kokoro_voices(self):
         return self.kokoro_voices.copy()

--- a/speech.py
+++ b/speech.py
@@ -40,7 +40,14 @@ PITCH_MIN = 0
 PITCH_MAX = 200
 RATE_MIN = 0
 RATE_MAX = 200
-
+VOICE_TO_LANG = {
+    'af': 'a', 'am': 'a',
+    'bf': 'b', 'bm': 'b',
+    'hf': 'h', 'hm': 'h',
+    'jf': 'j', 'jm': 'j',
+    'ef': 'e', 'em': 'e',
+    'ff': 'f',
+}
 
 class Speech(GstSpeechPlayer):
     __gsignals__ = {
@@ -98,9 +105,13 @@ class Speech(GstSpeechPlayer):
     def set_kokoro_voice(self, voice_name):
         if voice_name in self.kokoro_voices:
             self.current_kokoro_voice = voice_name
-            logger.debug(f"Kokoro voice set to: {voice_name}")
+            prefix = voice_name[:2]
+            lang_code = VOICE_TO_LANG.get(prefix, 'a')
+            if self.kokoro_pipeline:
+                self.kokoro_pipeline = KPipeline(lang_code=lang_code)
+            logger.debug(f"Kokoro voice set to: {voice_name}, lang: {lang_code}")
         else:
-            logger.warning(f"Invalid Kokoro voice: {voice_name}.")
+            logger.warning(f"Invalid Kokoro voice: {voice_name}.")   
 
     def get_available_kokoro_voices(self):
         return self.kokoro_voices.copy()


### PR DESCRIPTION
Summary
This PR addresses an issue where selecting a non-English Kokoro voice (e.g., hf_alpha for Hindi) continued using the English pipeline (lang_code='a'), leading to incorrect pronunciation.

The root cause was that the Kokoro pipeline was not updated when the voice changed.

Changes Made
- Added VOICE_TO_LANG mapping (voice prefix → language code)
- Updated setup_kokoro() to initialize the pipeline based on the selected voice
- Updated set_kokoro_voice() to switch the pipeline when the language changes
- Added safeguards to keep pipeline state consistent
- Avoided unnecessary pipeline reinitialization

Testing
Tested locally on Ubuntu:

- Verified English voice output
- Tested Hindi voice (hf_alpha) pipeline selection
- Observed correct language switching behavior in CLI-based tests
- No crashes observed during local testing

Follow-up Work
- Improve streaming smoothness
- Additional thread-safety refinements

Impact
This improves multilingual pronunciation by ensuring the appropriate G2P pipeline is selected based on the voice.