### PR TITLE
Fix offline fallback flow in chatbot mode (non-blocking, GTK-safe)

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -1364,10 +1364,17 @@ class SpeakActivity(activity.Activity):
                         llm_thread.start()
                     else:
                         # No internet, try SLM -> Brain
-                        response = self._try_slm_response(text)
-                        if not response:
-                            response = brain.respond(text)
-                        self.face.say(response)
+                        self.face.say("Thinking...")
+
+                        def fetch_offline():
+                            response = self._try_slm_response(text)
+                            if not response:
+                                response = brain.respond(text)
+                            GLib.idle_add(lambda: self.face.say(response) or False)
+
+                        t = threading.Thread(
+                            target=fetch_offline, daemon=True)
+                        t.start()
                 else:
                     # Use traditional brain chatbot
                     brain_response = brain.respond(text)


### PR DESCRIPTION
**Summary**

- Refactors offline chatbot logic to use a single async fallback flow.
 

**Changes**

- Unified flow: SLM → brain (async)
- Removed duplicate response execution
- Added immediate "Thinking..." feedback
- Moved processing to background thread
- Used GLib.idle_add for safe UI updates

**Result**

- No duplicate responses
- Smooth, non-blocking UI
- Consistent with online async behavior