### PR TITLE
docs: add setup troubleshooting for windows users #35

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,24 @@ The `not-gstreamer1` branch is a backport of features and bug fixes
 from the `master` branch for ongoing maintenance of the activity on
 Fedora 18 systems which don't have well-functioning GStreamer 1
 packages.
+
+## 🛠️ Cross-Platform Setup & Troubleshooting
+
+If you are contributing from **Windows, WSL, or macOS**, please note that the full Sugar Activity environment requires the Sugar Shell. However, you can still develop and test core AI modules.
+
+### 1. Common Issues
+* **`ModuleNotFoundError: No module named 'dbus'`**: This happens because `dbus` is a Linux-specific system bus. It will not work on native Windows. 
+* **`sugar-launch: command not found`**: This command only works inside a Linux environment with Sugar Desktop installed.
+
+### 2. Development Workflow by Platform
+
+| Platform | Capabilities | Recommended Approach |
+| :--- | :--- | :--- |
+| **Linux (Ubuntu/Fedora)** | Full Activity Testing | Install `sugar-desktop` and use `sugar-launch`. |
+| **Windows (Native)** | Logic & AI Testing | Test individual modules (TTS, LLM, Spell Check) using `python -m py_compile` or unit tests. |
+| **Windows (WSL2)** | Near-Full Testing | Use WSL with an X-Server (like GWSL) to run Linux GUI apps. |
+
+### 3. Testing without Sugar Environment
+To verify your code changes without running the full UI:
+1. **Syntax Check:** `python -m py_compile activity.py`
+2. **Module Test:** Run specific logic files directly (e.g., `python GenAI/spell_handler.py`) if they have a `if __name__ == "__main__":` block.


### PR DESCRIPTION
I have updated the README.md to include a dedicated "Cross-Platform Setup & Troubleshooting" section.

Key Additions:
Error Explanation: Clarified why dbus and sugar-launch fail on non-Sugar environments.
Platform Matrix: Added a table comparing capabilities across Native Windows, WSL2, and Linux.
Alternative Testing Workflow: Documented how to verify code changes using python -m py_compile and individual module testing when the full Sugar Shell is unavailable.

Why this is important?
This documentation improvement reduces friction for GSoC aspirants and contributors who may not have a native Linux/Sugar setup but want to contribute to the GenAI, TTS, or Translation logic of the activity.

Changes Made
Updated README.md with troubleshooting steps and platform-specific guidance.mn