### PR TITLE
Refactor: Rename Mouth class to MouthData to avoid naming conflict

### DIFF
--- a/faceselect.py
+++ b/faceselect.py
@@ -63,7 +63,7 @@ class Eye(object):
         self.circ = circ
 
 
-class Mouth(object):
+class MouthData(object):
 
     def from_values(self, x, y, w, h, pixbuf):
         self.x = x
@@ -170,7 +170,7 @@ class FaceSelector(Gtk.VBox):
         self.emit('face-processed', self._drawing.get_pixbuf(),
                   Eye(left_eye_center, left_eye_circ),
                   Eye(right_eye_center, right_eye_circ),
-                  Mouth().create(mouth_y, mouth_x_left, mouth_x_right,
+                  MouthData().create(mouth_y, mouth_x_left, mouth_x_right,
                                  self._drawing.get_pixbuf()))
 
     def _add_widget(self, widget):

--- a/photoface.py
+++ b/photoface.py
@@ -31,7 +31,7 @@ import sugar3.graphics.style as style
 import voice
 import speech
 from faceselect import Eye
-from faceselect import Mouth
+from faceselect import MouthData
 
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -99,7 +99,7 @@ class Status(object):
 
         m = data['mouth']
         mouth_pixbuf = _b64_to_pixbuf(m['pixbuf'])
-        self.mouth = Mouth()
+        self.mouth = MouthData()
         self.mouth.from_values(m['x'], m['y'], m['w'], m['h'], mouth_pixbuf)
 
         return self


### PR DESCRIPTION
### Summary
This PR resolves a naming conflict by renaming the existing `Mouth` class to `MouthData`.

### Problem
The project uses a `Mouth` structure in multiple places, and having the same class name created ambiguity and potential confusion during imports and usage. It was unclear whether `Mouth` referred to data representation or processing logic.

### Solution
- Renamed `Mouth` → `MouthData` to clearly indicate it represents structured data
- Updated all references accordingly in the relevant files

### Impact
- Improves code readability and maintainability
- Prevents naming conflicts and confusion in future development
- Makes the role of the class more explicit (data container vs logic)

### Files Changed
- `faceselect.py`
- `photoface.py`