### PR TITLE
add Debian setup instructions for blis build error (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,20 @@ latest stable release of Fedora and Debian distributions.
 
 Branch not-gstreamer1
 
+=====================
+
+The `not-gstreamer1` branch is a backport of features and bug fixes
+from the `master` branch for ongoing maintenance of the activity on
+Fedora 18 systems which don't have well-functioning GStreamer 1
+packages.
+
 ## Debian Setup Notes
 
 Before installing Python dependencies on Debian,
 ensure build tools are installed:
-
-    sudo apt install python3-dev build-essential gcc
+```bash
+sudo apt install python3-dev build-essential gcc
+```
 
 If `blis` fails to build during pip install, it is caused
 by missing system-level compiler dependencies.
@@ -61,9 +69,3 @@ The above command resolves it.
 ```
 
 ---
-=====================
-
-The `not-gstreamer1` branch is a backport of features and bug fixes
-from the `master` branch for ongoing maintenance of the activity on
-Fedora 18 systems which don't have well-functioning GStreamer 1
-packages.

--- a/README.md
+++ b/README.md
@@ -67,5 +67,3 @@ If `blis` fails to build during pip install, it is caused
 by missing system-level compiler dependencies.
 The above command resolves it.
 ```
-
----

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ of [Sugar](https://github.com/sugarlabs/sugar), with dependencies on
 latest stable release of Fedora and Debian distributions.
 
 Branch not-gstreamer1
+
+## Debian Setup Notes
+
+Before installing Python dependencies on Debian,
+ensure build tools are installed:
+
+    sudo apt install python3-dev build-essential gcc
+
+If `blis` fails to build during pip install, it is caused
+by missing system-level compiler dependencies.
+The above command resolves it.
+```
+
+---
 =====================
 
 The `not-gstreamer1` branch is a backport of features and bug fixes


### PR DESCRIPTION
## What this PR does
Adds a new "Debian Setup Notes" section to README.md 
documenting the blis wheel build error and its fix.

## Why
While setting up the project on Debian (x86_64) with 
Python 3.13, the installation failed when pip attempted 
to build `blis` from source due to missing system-level 
compiler dependencies.

## Changes
- Added Debian-specific setup instructions to README.md
- Documents the `sudo apt install python3-dev build-essential gcc` 
  fix for the blis build failure

## Related Issue
Fixes #103