### PR TITLE
ignore stale ai replies from older requests

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -201,6 +201,8 @@ class SpeakActivity(activity.Activity):
         # Load personas from `personas.json`
         self._personas = {}
         self._current_persona = None
+        self._response_request_id = 0
+        self._response_request_lock = threading.Lock()
 
         with open('personas.json', 'r') as f:
             self._personas = json.load(f)
@@ -1324,12 +1326,24 @@ class SpeakActivity(activity.Activity):
             logging.error(f"Error using SLM model: {e}")
             return None
 
+    def _next_response_request_id(self):
+        """Advance and return the current chatbot response request id."""
+        with self._response_request_lock:
+            self._response_request_id += 1
+            return self._response_request_id
+
+    def _is_latest_response_request(self, request_id):
+        """Check whether request_id is still the newest request."""
+        with self._response_request_lock:
+            return request_id == self._response_request_id
+
     def _speak_the_text(self, entry, text):
         self._remove_idle()
         if text:
             self.face.look_ahead()
 
             if self._mode == MODE_BOT: # Chatbot mode
+                request_id = self._next_response_request_id()
 
                 # ORDER OF PRIORITY:
                 # 1. LLM (if internet is available)
@@ -1353,6 +1367,11 @@ class SpeakActivity(activity.Activity):
                                 response = brain.respond(text)
 
                             def safe_face_say():
+                                if not self._is_latest_response_request(request_id):
+                                    logger.debug(
+                                        'Skipping stale chatbot response for request %s',
+                                        request_id)
+                                    return False
                                 self.face.say(response)
                                 return False
                             GLib.idle_add(safe_face_say)
@@ -1367,7 +1386,8 @@ class SpeakActivity(activity.Activity):
                         response = self._try_slm_response(text)
                         if not response:
                             response = brain.respond(text)
-                        self.face.say(response)
+                        if self._is_latest_response_request(request_id):
+                            self.face.say(response)
                 else:
                     # Use traditional brain chatbot
                     brain_response = brain.respond(text)


### PR DESCRIPTION
## issue
Chatbot responses are fetched asynchronously. If a user sends another prompt before the previous one returns, stale/older replies can still be spoken, causing out-of-order conversation.

## fix
- add monotonic chatbot request ids
- add thread-safe helpers to mark/check latest request
- gate `face.say(...)` so only the latest request is spoken
- keep existing fallback order (LLM -> SLM -> brain)

## impact
Prevents stale responses from talking over newer context, so chat flow stays correct and predictable under fast input or slow network.
