### PR TITLE
Fix Kokoro language pipeline: multi-lang dispatch, null audio guard, warning fixes     

### DIFF
--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -151,7 +151,7 @@ class KPipeline:
         else:
             f = hf_hub_download(repo_id=self.repo_id, filename=f'voices/{voice}.pt')
             if not voice.startswith(self.lang_code):
-                v = LANG_CODES.get(voice, voice)
+                v = LANG_CODES.get(voice[0], voice)
                 p = LANG_CODES.get(self.lang_code, self.lang_code)
                 logger.warning(f'Language mismatch, loading {v} voice into {p} pipeline.')
         pack = torch.load(f, weights_only=True)

--- a/speech.py
+++ b/speech.py
@@ -54,9 +54,11 @@ class Speech(GstSpeechPlayer):
         self.pipeline = None
         
         # Initialize Kokoro pipeline if available
-        self.kokoro_pipeline = None
+        self.kokoro_pipeline = None      # default 'a' pipeline (backward compat)
+        self.kokoro_pipelines = {}       # lang_code -> KPipeline
+        self.kokoro_model = None         # shared KModel across all pipelines
         if KOKORO_AVAILABLE:
-            threading.Thread(target=self.setup_kokoro).start()
+            threading.Thread(target=self.setup_kokoro, daemon=True).start()
         
         # Predefined Kokoro voices for future GUI selection - TODO
         self.kokoro_voices = [
@@ -77,7 +79,20 @@ class Speech(GstSpeechPlayer):
             self._cb[cb] = None
 
     def setup_kokoro(self):
-        self.kokoro_pipeline = KPipeline(lang_code='a')
+        repo_id = 'hexgrad/Kokoro-82M'
+        self.kokoro_pipeline = KPipeline(lang_code='a', repo_id=repo_id)
+        self.kokoro_model = self.kokoro_pipeline.model
+        self.kokoro_pipelines['a'] = self.kokoro_pipeline
+
+    def _init_pipeline_for_lang(self, lang_code):
+        """Lazily initialize a KPipeline for a new language, reusing the shared KModel."""
+        try:
+            repo_id = self.kokoro_pipeline.repo_id
+            pipeline = KPipeline(lang_code=lang_code, model=self.kokoro_model, repo_id=repo_id)
+            self.kokoro_pipelines[lang_code] = pipeline
+            logger.debug(f"Initialized Kokoro pipeline for lang_code='{lang_code}'")
+        except Exception as e:
+            logger.error(f"Failed to initialize Kokoro pipeline for lang_code='{lang_code}': {e}")
 
     def disconnect_all(self):
         for cb in ['peak', 'wave', 'idle']:
@@ -98,6 +113,12 @@ class Speech(GstSpeechPlayer):
     def set_kokoro_voice(self, voice_name):
         if voice_name in self.kokoro_voices:
             self.current_kokoro_voice = voice_name
+            lang_code = voice_name[0]
+            # Lazily initialize a pipeline for the new language if we don't have one yet
+            if lang_code not in self.kokoro_pipelines and self.kokoro_model is not None:
+                threading.Thread(
+                    target=self._init_pipeline_for_lang, args=(lang_code,), daemon=True
+                ).start()
             logger.debug(f"Kokoro voice set to: {voice_name}")
         else:
             logger.warning(f"Invalid Kokoro voice: {voice_name}.")
@@ -326,6 +347,7 @@ class Speech(GstSpeechPlayer):
 
     def _stream_kokoro_audio(self, text, voice):
         """Stream Kokoro audio chunks to the GStreamer pipeline"""
+        appsrc = None
         try:
             # Getting the appsrc element
             appsrc = self.pipeline.get_by_name('kokoro_src')
@@ -339,10 +361,27 @@ class Speech(GstSpeechPlayer):
             )
             appsrc.set_property("caps", caps)
 
-            audio_generator = self.kokoro_pipeline(text, voice=voice) # actual audio generation by kokoro
+            # Select the pipeline matching this voice's language; fall back to the
+            # default 'a' (American English) pipeline if the language-specific one
+            # hasn't been initialized yet.
+            lang_code = voice[0]
+            pipeline = self.kokoro_pipelines.get(lang_code) or self.kokoro_pipeline
+            if pipeline is None:
+                logger.error("Kokoro pipeline not ready yet")
+                return
+            if lang_code not in self.kokoro_pipelines:
+                logger.warning(
+                    f"Pipeline for lang_code='{lang_code}' not ready, "
+                    "falling back to American English pipeline"
+                )
+
+            audio_generator = pipeline(text, voice=voice) # actual audio generation by kokoro
 
             # Stream audio chunks
             for i, (gs, ps, audio_chunk) in enumerate(audio_generator):
+                if audio_chunk is None:
+                    logger.debug(f"Skipping chunk {i} with no audio")
+                    continue
                 # Convert tensor to numpy array then to bytes
                 data_bytes = audio_chunk.numpy().tobytes()
                 


### PR DESCRIPTION
## Problem                                                                                                                                                                           
  - `setup_kokoro()` hardcoded `lang_code='a'` — selecting a Japanese, Chinese,                                                                                                        
    Spanish, etc. voice still ran text through the English G2P, producing bad output                                                                                                   
  - `set_kokoro_voice()` only updated the voice name, never switched the underlying pipeline                                                                                           
  - `audio_chunk` was dereferenced without a None check, causing `AttributeError` on quiet chunks                                                                                      
  - `appsrc` was referenced in the `except` block before being assigned → potential `NameError`                                                                                        
  - `LANG_CODES.get(voice, voice)` used the full voice name (e.g. `jf_alpha`) as a dict key;                                                                                           
    it should be `voice[0]` (`j`) which is the actual key                                                                                                                              
                                                                                                                                                                                       
  ## Changes                                                                                                                                                                           
  - `speech.py`: add `kokoro_pipelines` dict and shared `kokoro_model`; lazy-init per-language                                                                                         
    pipelines in background threads reusing the loaded KModel; dispatch to correct pipeline in                                                                                         
    `_stream_kokoro_audio`; fix null guard and `appsrc` init; pass `repo_id` explicitly                                                                                                
  - `kokoro/pipeline.py`: fix `LANG_CODES.get(voice[0], voice)` in language-mismatch warning                 