### PR TITLE
feat: add language fallback handler for Kokoro TTS

### DIFF
--- a/activity/activity-speak-ai.svg
+++ b/activity/activity-speak-ai.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="55" height="55" viewBox="0 0 55 55"
+     version="1.1">
+
+  <circle cx="27" cy="26" r="18"
+          fill="#FF8C00" stroke="#C46200" stroke-width="1.5"/>
+
+  <circle cx="20" cy="22" r="3.5" fill="#FFFFFF"/>
+  <circle cx="34" cy="22" r="3.5" fill="#FFFFFF"/>
+  <circle cx="21" cy="22" r="2" fill="#1A1A1A"/>
+  <circle cx="35" cy="22" r="2" fill="#1A1A1A"/>
+
+  <ellipse cx="27" cy="32" rx="6" ry="4" fill="#FFFFFF"/>
+  <ellipse cx="27" cy="33" rx="4" ry="2.5" fill="#C46200"/>
+
+  <rect x="36" y="4" width="16" height="11"
+        rx="3" ry="3" fill="#00B4D8"/>
+  <polygon points="39,15 36,19 43,15" fill="#00B4D8"/>
+
+  <circle cx="40" cy="9.5" r="1.5" fill="#FFFFFF"/>
+  <circle cx="44" cy="9.5" r="1.5" fill="#FFFFFF"/>
+  <circle cx="48" cy="9.5" r="1.5" fill="#FFFFFF"/>
+
+  <path d="M 8 44 Q 27 39 46 44"
+        fill="none" stroke="#00B4D8"
+        stroke-width="2" stroke-linecap="round"/>
+  <path d="M 4 50 Q 27 43 50 50"
+        fill="none" stroke="#00B4D8"
+        stroke-width="1.5" stroke-linecap="round"
+        opacity="0.6"/>
+
+</svg>

--- a/utils/language_fallback.py
+++ b/utils/language_fallback.py
@@ -1,0 +1,106 @@
+"""
+Language fallback handler for Speak-AI Kokoro TTS pipeline.
+
+When a requested language is not supported by Kokoro, this module
+handles graceful fallback with user-friendly logging.
+
+Author: Uday Kumar Reddy
+GSoC 2026 - Speak-AI Multilingual Support
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Kokoro's officially supported lang_codes as of v0.9.4
+KOKORO_SUPPORTED = {
+    'a': 'English (American)',
+    'b': 'English (British)',
+    'e': 'Spanish',
+    'f': 'French',
+    'h': 'Hindi',
+    'i': 'Italian',
+    'j': 'Japanese',
+    'p': 'Portuguese (Brazilian)',
+    'z': 'Chinese (Mandarin)',
+}
+
+# ISO 639-1 codes → Kokoro lang_codes
+ISO_TO_KOKORO = {
+    'en': 'a',
+    'en-gb': 'b',
+    'es': 'e',
+    'fr': 'f',
+    'hi': 'h',
+    'it': 'i',
+    'ja': 'j',
+    'pt': 'p',
+    'pt-br': 'p',
+    'zh': 'z',
+    'zh-cn': 'z',
+}
+
+DEFAULT_LANG = 'a'  # English fallback
+
+
+def resolve_lang_code(requested: str) -> tuple[str, bool]:
+    """
+    Resolve a language code to a Kokoro-supported lang_code.
+
+    Args:
+        requested: ISO 639-1 code (e.g. 'hi', 'fr') or
+                   Kokoro code (e.g. 'h', 'f') or
+                   language name (e.g. 'hindi', 'french')
+
+    Returns:
+        Tuple of (resolved_lang_code, is_native_support)
+        is_native_support is False when falling back to English
+    """
+    req = requested.lower().strip()
+
+    # Already a valid Kokoro code
+    if req in KOKORO_SUPPORTED:
+        return req, True
+
+    # ISO 639-1 code
+    if req in ISO_TO_KOKORO:
+        return ISO_TO_KOKORO[req], True
+
+    # Language name fallback
+    name_map = {v.lower().split(' ')[0]: k
+                for k, v in KOKORO_SUPPORTED.items()}
+    if req in name_map:
+        return name_map[req], True
+
+    # Not supported — fallback to English
+    logger.warning(
+        f"Language '{requested}' is not supported by Kokoro TTS. "
+        f"Falling back to English. "
+        f"Supported languages: {list(KOKORO_SUPPORTED.values())}"
+    )
+    return DEFAULT_LANG, False
+
+
+def get_supported_languages() -> dict:
+    """
+    Return all languages supported by Kokoro TTS.
+
+    Returns:
+        Dict mapping Kokoro lang_code to language name
+    """
+    return KOKORO_SUPPORTED.copy()
+
+
+def is_non_latin_script(lang_code: str) -> bool:
+    """
+    Check if a language uses a non-Latin script.
+    These languages need G2P preprocessing before Kokoro.
+
+    Args:
+        lang_code: Kokoro lang_code
+
+    Returns:
+        True if language needs special script handling
+    """
+    NON_LATIN = {'h', 'j', 'z'}  # Hindi, Japanese, Chinese
+    return lang_code in NON_LATIN


### PR DESCRIPTION
Adds `utils/language_fallback.py` to safely handle language codes for Kokoro TTS.

What this fixes:
- Prevents crashes when unsupported language codes are passed to KPipeline
- Falls back to English with a warning log instead of failing silently
- Maps ISO codes (hi, fr), Kokoro codes (h, f), and names (hindi, french) correctly
- Adds helper functions for future language UI and G2P routing

How to test:
python3 -c "from utils.language_fallback import resolve_lang_code; print(resolve_lang_code('hi'))"
# Output: ('h', True)

python3 -c "from utils.language_fallback import resolve_lang_code; print(resolve_lang_code('xyz'))"
# Output: ('a', False) + warning log

Relates to GSoC 2026 Speak-AI Multilingual Support proposal.