### PR TITLE
Style: fix E303 too many blank lines in activity.py

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -312,7 +312,6 @@ class SpeakActivity(activity.Activity):
         self._persona_button.connect('clicked', self._face_palette_cb)
         toolbox.toolbar.insert(self._persona_button, -1)
 
-
         self._kokoro_button = ToolButton('module-language')
         self._kokoro_button.set_tooltip(_('Choose Kokoro voice:'))
         self._make_kokoro()


### PR DESCRIPTION
>Fixed style violations in activity.py .

- Removed extra blank lines to satisfy E303 as per the project's [.flake8 configuration](https://github.com/sugarlabs/speak-ai/blob/main/.flake8)