### PR TITLE
fix: use __file__ path for API_KEY.txt lookup

### DIFF
--- a/LLM.py
+++ b/LLM.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import json
 import socket
@@ -6,7 +7,7 @@ import logging
 #TODO: Dont hard code these, need to see how sugar as a whole manages API Keys
 API_URL = "https://ai.sugarlabs.org/ask-llm-prompted"
 try:
-    with open("API_KEY.txt", "r") as f:
+    with open(os.path.join(os.path.dirname(__file__), "API_KEY.txt"), "r") as f:
         API_KEY = f.read().strip()
 except OSError:
     logging.error("Missing API_KEY.txt file.")


### PR DESCRIPTION
When someone downloads speak-ai from the browser or Activity wiki, Sugar launches it from a different working directory — not the activity folder.  So open("API_KEY.txt") fails silently and the activity just shows "unable to launch" with no clear error. I faced this exact issue, and using os.path.dirname(__file__) fixes it by always looking for API_KEY.txt next to LLM.py regardless of where Sugar launched from.

## Test Video Link 

https://drive.google.com/file/d/1MWZA1dKCkh0B5uCK3pYlXkdRjPfhBD0n/view?usp=sharing