### PR TITLE
fix: remove raise inside except in gguf_inference

### DIFF
--- a/GenAI/gguf_inference.py
+++ b/GenAI/gguf_inference.py
@@ -24,7 +24,7 @@ try:
     GGUF_AVAILABLE = True
 except ImportError:
     GGUF_AVAILABLE = False
-    raise ImportError("llama-cpp-python is required for GGUF models. Please install via pip")
+    # llama-cpp-python not installed — GGUF disabled, TTS still works
 
 # Suppress warnings for cleaner output
 warnings.filterwarnings("ignore")


### PR DESCRIPTION
The except ImportError block sets GGUF_AVAILABLE = False to signal graceful degradation,, that was nice exception handling block but then immediately raises the same exception — making the flag pointless. Any code that checks GGUF_AVAILABLE never gets a chance to run because the activity crashes first. Removing the raise lets the flag do its job — TTS works normally and LLM is simply disabled when llama-cpp-python is not installed.  and (llma-cpp-python needs whole c compiler or precompiled weheel, to protect the crash) 

## Test Video Link

https://drive.google.com/file/d/1MWZA1dKCkh0B5uCK3pYlXkdRjPfhBD0n/view?usp=sharing