### PR TITLE
fix: UnboundLocalError for os in pipeline.py on Python 3.13

### DIFF
--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -101,7 +101,7 @@ class KPipeline:
             if device is None:
                 if torch.cuda.is_available():
                     device = 'cuda'
-                elif os.environ.get('PYTORCH_ENABLE_MPS_FALLBACK') == '1' and torch.backends.mps.is_available():
+                elif __import__('os').environ.get('PYTORCH_ENABLE_MPS_FALLBACK') == '1' and torch.backends.mps.is_available():
                     device = 'mps'
                 else:
                     device = 'cpu'


### PR DESCRIPTION
The os module becomes unbound inside the setup_kokoro thread on Python 3.13 due to stricter scoping rules, causing an UnboundLocalError. Using __import__('os') fetches the module directly at the point of use, bypassing the scoping issue entirely.


## Test video link 

https://drive.google.com/file/d/1MWZA1dKCkh0B5uCK3pYlXkdRjPfhBD0n/view?usp=sharing