### PR TITLE
fix: initialize appsrc to None to prevent UnboundLocalError in Kokoro audio error path

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -326,6 +326,7 @@ class Speech(GstSpeechPlayer):
 
     def _stream_kokoro_audio(self, text, voice):
         """Stream Kokoro audio chunks to the GStreamer pipeline"""
+        appsrc = None # Initialize before try block to prevent UnboundLocalError
         try:
             # Getting the appsrc element
             appsrc = self.pipeline.get_by_name('kokoro_src')
@@ -360,7 +361,7 @@ class Speech(GstSpeechPlayer):
         except Exception as e:
             # Signalling EOS here as well, but I'm adding error to logs
             logger.error(f"Error in Kokoro audio streaming: {e}")
-            if appsrc:
+            if appsrc is not None:
                 appsrc.emit("end-of-stream")
 
     def speak(self, status, text):


### PR DESCRIPTION
Fixes #68
## Summary
Fixes a `NameError`/`UnboundLocalError` that occurs in `_stream_kokoro_audio()` 
when an exception is raised before `appsrc` is assigned.

## Problem
In the `_stream_kokoro_audio()` method in `speech.py`, the `appsrc` variable 
is assigned inside the `try` block. If an exception occurs before that 
assignment (e.g., pipeline not ready, GStreamer error), the `except` block 
tries to reference `appsrc` which doesn't exist yet, causing:
UnboundLocalError: local variable 'appsrc' referenced before assignment

## Changes
- Initialize `appsrc = None` before the `try` block
- Change `if appsrc:` to `if appsrc is not None:` in the `except` block

## Files Changed
- `speech.py` — `_stream_kokoro_audio()` method

## Testing
- Verified the fix prevents `UnboundLocalError` when pipeline 
  initialization fails before `appsrc` is assigned
- Existing Kokoro audio streaming behavior unchanged