### PR TITLE
fix: handle DBus exception when Journal service is unavailable in photo face selection

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -1067,23 +1067,41 @@ class SpeakActivity(activity.Activity):
             logger.warning(f"Persona voice {persona_voice_name} not found in available Kokoro voices")
 
     def _photo_face_cb(self, widget):
-        chooser = ObjectChooser(parent=self,
-                                what_filter=mime.GENERIC_TYPE_IMAGE)
+        try:
+            chooser = ObjectChooser(parent=self,
+                                    what_filter=mime.GENERIC_TYPE_IMAGE)
+        except Exception as e:
+            logger.warning(f"Could not open photo chooser: {e}")
+            from gi.repository import Gtk as _Gtk
+            dialog = _Gtk.MessageDialog(
+                parent=self,
+                flags=0,
+                message_type=_Gtk.MessageType.WARNING,
+                buttons=_Gtk.ButtonsType.OK,
+                text=_("Photo selection is not available in this environment.")
+            )
+            dialog.run()
+            dialog.destroy()
+            return
 
-        result = chooser.run()
-        if result == Gtk.ResponseType.ACCEPT:
-            jobject = chooser.get_selected_object()
-            if jobject and jobject.file_path:
-                selector = FaceSelector(jobject.file_path)
-                selector.connect('face-processed',
-                                 self._photo_face_processed_cb)
-                selector.connect('cancel', self._photo_face_cancel_cb)
-                self._notebook.append_page(selector, Gtk.Label(''))
-                selector.show()
+        try:
+            result = chooser.run()
+            if result == Gtk.ResponseType.ACCEPT:
+                jobject = chooser.get_selected_object()
+                if jobject and jobject.file_path:
+                    selector = FaceSelector(jobject.file_path)
+                    selector.connect('face-processed',
+                                     self._photo_face_processed_cb)
+                    selector.connect('cancel', self._photo_face_cancel_cb)
+                    self._notebook.append_page(selector, Gtk.Label(''))
+                    selector.show()
 
-                num = self._notebook.page_num(selector)
-                self._notebook.set_current_page(num)
-        chooser.destroy()
+                    num = self._notebook.page_num(selector)
+                    self._notebook.set_current_page(num)
+        except Exception as e:
+            logger.warning(f"Error during photo selection: {e}")
+        finally:
+            chooser.destroy()
 
     def _photo_face_processed_cb(self, widget, *face_data):
         lighter = style.Color(self._colors[_lighter_color(self._colors)])

--- a/activity.py
+++ b/activity.py
@@ -25,6 +25,7 @@
 import logging
 import os
 import dbus
+import dbus.exceptions
 import subprocess
 import json
 import random
@@ -58,6 +59,7 @@ from sugar3.graphics.toolbarbox import ToolbarBox, ToolbarButton
 from sugar3.activity.widgets import ActivityToolbarButton
 from sugar3.activity.widgets import StopButton
 from sugar3.graphics.objectchooser import ObjectChooser
+from sugar3.graphics.alert import NotifyAlert
 
 from sugar3 import mime
 from sugar3 import profile
@@ -1070,21 +1072,6 @@ class SpeakActivity(activity.Activity):
         try:
             chooser = ObjectChooser(parent=self,
                                     what_filter=mime.GENERIC_TYPE_IMAGE)
-        except Exception as e:
-            logger.warning(f"Could not open photo chooser: {e}")
-            from gi.repository import Gtk as _Gtk
-            dialog = _Gtk.MessageDialog(
-                parent=self,
-                flags=0,
-                message_type=_Gtk.MessageType.WARNING,
-                buttons=_Gtk.ButtonsType.OK,
-                text=_("Photo selection is not available in this environment.")
-            )
-            dialog.run()
-            dialog.destroy()
-            return
-
-        try:
             result = chooser.run()
             if result == Gtk.ResponseType.ACCEPT:
                 jobject = chooser.get_selected_object()
@@ -1095,13 +1082,22 @@ class SpeakActivity(activity.Activity):
                     selector.connect('cancel', self._photo_face_cancel_cb)
                     self._notebook.append_page(selector, Gtk.Label(''))
                     selector.show()
-
                     num = self._notebook.page_num(selector)
                     self._notebook.set_current_page(num)
-        except Exception as e:
-            logger.warning(f"Error during photo selection: {e}")
+        except dbus.exceptions.DBusException as e:
+            logger.warning(f"Could not open photo chooser: {e}")
+            alert = NotifyAlert()
+            alert.props.title = _('Photo Selection Unavailable')
+            alert.props.msg = _('Photo selection is not available'
+                                ' in this environment.')
+            alert.connect('response', lambda a, r: self.remove_alert(a))
+            self.add_alert(alert)
+            alert.show()
         finally:
-            chooser.destroy()
+            try:
+                chooser.destroy()
+            except Exception:
+                pass
 
     def _photo_face_processed_cb(self, widget, *face_data):
         lighter = style.Color(self._colors[_lighter_color(self._colors)])


### PR DESCRIPTION
Fixes #47

## Summary
Fixes an unhandled `DBusException` that occurs when clicking 
"Set face from photo" outside the Sugar environment.

## Problem
When the `org.laptop.Journal` D-Bus service is not running, 
`ObjectChooser` raises an unhandled exception causing a crash:

## Changes
- Wrapped `ObjectChooser` initialization in a `try/except` block
- Wrapped `chooser.run()` in a `try/except` block  
- Added user-friendly dialog when photo selection is unavailable
- Added `finally` block to ensure `chooser.destroy()` always runs

## Files Changed
- `activity.py` — `_photo_face_cb()` method

## Testing
- Verified the fix shows a friendly message instead of crashing
  when Journal service is unavailable
- Verified normal photo selection flow is unchanged